### PR TITLE
Fix profile screen without saved data

### DIFF
--- a/src/UserProfileScreen.jsx
+++ b/src/UserProfileScreen.jsx
@@ -1,17 +1,20 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useTheme } from "./ThemeContext";
 
 export default function UserProfileScreen() {
   const { theme } = useTheme();
+  const navigate = useNavigate();
   const [profile, setProfile] = useState(null);
 
   useEffect(() => {
     const storedProfile = localStorage.getItem("userProfile");
     if (storedProfile) {
       setProfile(JSON.parse(storedProfile));
+    } else {
+      navigate("/edit-profile", { replace: true });
     }
-  }, []);
+  }, [navigate]);
 
   if (!profile) {
     return (


### PR DESCRIPTION
## Summary
- add navigation to `/edit-profile` when no profile data is found

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*
- `npm start` *(app compiles)*

------
https://chatgpt.com/codex/tasks/task_e_6845806c7c48833185bd2f74dc11ac1e