### PR TITLE
Fix profile page and unify theme

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
-import { ThemeProvider } from "./ThemeContext";
+import { ThemeProvider, useTheme } from "./ThemeContext";
 
 import WelcomeScreen from "./WelcomeScreen";
 import SignUpScreen from "./SignUpScreen";
@@ -15,11 +15,16 @@ import MatchesScreen from "./MatchesScreen";
 
 function AppContent() {
   const location = useLocation();
+  const { theme } = useTheme();
   const hideNavOn = ["/", "/login", "/signup", "/forgot-password"];
   const shouldShowNav = !hideNavOn.includes(location.pathname);
 
   return (
-    <div className="min-h-screen bg-black grid">
+    <div
+      className={`min-h-screen grid transition-colors duration-300 ${
+        theme === "light" ? "bg-warm text-black" : "bg-darkbg text-textwarm"
+      }`}
+    >
       {/* iPhone 15 Pro Max frame */}
       {/* <div className="w-[430px] h-[932px] rounded-[38px] border-[12px] border-zinc-800 shadow-2xl overflow-hidden relative"> */}
       {/* Dynamic Island */}

--- a/src/BottomNavBar.jsx
+++ b/src/BottomNavBar.jsx
@@ -1,24 +1,10 @@
 import { NavLink } from "react-router-dom";
 import { FaHome, FaComment, FaUser, FaMoon, FaSun } from "react-icons/fa";
-import { useEffect, useState } from "react";
+import { useTheme } from "./ThemeContext";
 
 export default function BottomNavBar() {
-  const [isDark, setIsDark] = useState(true);
-
-  useEffect(() => {
-    document.documentElement.classList.add("dark");
-  }, []);
-
-  const toggleTheme = () => {
-    const html = document.documentElement;
-    if (html.classList.contains("dark")) {
-      html.classList.remove("dark");
-      setIsDark(false);
-    } else {
-      html.classList.add("dark");
-      setIsDark(true);
-    }
-  };
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === "dark";
 
   const navItemClass = ({ isActive }) =>
     `flex flex-col items-center text-xs gap-1 transition duration-200 

--- a/src/ChatConversationScreen.jsx
+++ b/src/ChatConversationScreen.jsx
@@ -1,11 +1,13 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useRef, useState } from "react";
+import { useTheme } from "./ThemeContext";
 
 export default function ChatConversationScreen() {
   const { userId } = useParams();
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState("");
   const chatRef = useRef(null);
+  const { theme } = useTheme();
 
   const partner = {
     id: userId,
@@ -69,10 +71,19 @@ export default function ChatConversationScreen() {
   };
 
   return (
-    <div className="w-full max-w-[430px] h-[800px] mx-auto bg-black text-white p-4 rounded-2xl shadow-xl flex flex-col">
+    <div
+      className={`w-full max-w-[430px] h-[800px] mx-auto p-4 rounded-2xl shadow-xl flex flex-col transition-colors duration-300 ${
+        theme === "light" ? "bg-warm text-black" : "bg-darkbg text-textwarm"
+      }`}
+    >
       <h2 className="text-lg font-bold mb-4">Чат з {partner.name}</h2>
 
-      <div ref={chatRef} className="flex-1 bg-zinc-800 rounded-lg p-4 overflow-y-auto space-y-4">
+      <div
+        ref={chatRef}
+        className={`flex-1 rounded-lg p-4 overflow-y-auto space-y-4 ${
+          theme === "light" ? "bg-zinc-100" : "bg-zinc-800"
+        }`}
+      >
         {messages.map(msg => (
           <div key={msg.id} className={`flex ${msg.side === "right" ? "justify-end" : "justify-start"}`}>
             <div className={`flex items-end gap-2 max-w-[70%] ${msg.side === "right" ? "flex-row-reverse" : ""}`}>
@@ -80,7 +91,11 @@ export default function ChatConversationScreen() {
                 <img src={msg.avatar} alt={msg.from} className="w-8 h-8 rounded-full" />
               )}
               <div>
-                <div className="bg-zinc-900 px-4 py-2 rounded-xl text-sm text-white">
+                <div
+                  className={`px-4 py-2 rounded-xl text-sm ${
+                    theme === "light" ? "bg-zinc-200 text-black" : "bg-zinc-900 text-white"
+                  }`}
+                >
                   {msg.text}
                 </div>
                 <div className="text-xs text-gray-500 mt-1 text-right">{msg.time}</div>
@@ -96,7 +111,9 @@ export default function ChatConversationScreen() {
           value={input}
           onChange={e => setInput(e.target.value)}
           placeholder="Напишіть повідомлення..."
-          className="flex-1 bg-zinc-900 text-white px-4 py-2 rounded-lg focus:outline-none"
+          className={`flex-1 px-4 py-2 rounded-lg focus:outline-none ${
+            theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-white"
+          }`}
         />
         <button
           onClick={handleSend}

--- a/src/EditProfileScreen.jsx
+++ b/src/EditProfileScreen.jsx
@@ -1,8 +1,13 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useTheme } from "./ThemeContext";
 
 export default function EditProfileScreen() {
   const navigate = useNavigate();
+  const { theme } = useTheme();
+  const inputClass = `w-full px-4 py-3 rounded-xl placeholder-gray-400 ${
+    theme === "light" ? "bg-white text-black" : "bg-zinc-800 text-white"
+  }`;
   const popularInterests = [
     "Подорожі", "Музика", "Фільми", "Спорт", "Йога",
     "Танці", "Кавові побачення", "Відеоігри", "Меми",
@@ -126,7 +131,11 @@ export default function EditProfileScreen() {
   };
 
   return (
-    <div className="w-full max-w-md mx-auto bg-black text-white min-h-screen">
+    <div
+      className={`w-full max-w-md mx-auto min-h-screen transition-colors duration-300 ${
+        theme === "light" ? "bg-warm text-black" : "bg-darkbg text-textwarm"
+      }`}
+    >
       <div className="p-6 space-y-4 overflow-y-auto pb-24">
         <h2 className="text-xl font-bold text-center">Редагування профілю</h2>
 
@@ -143,7 +152,9 @@ export default function EditProfileScreen() {
                 />
                 <button
                   onClick={() => handlePhotoRemove(idx)}
-                  className="absolute top-1 right-1 bg-black bg-opacity-50 text-white text-xs px-2 rounded-full"
+                  className={`absolute top-1 right-1 text-xs px-2 rounded-full ${
+                    theme === "light" ? "bg-white/70 text-black" : "bg-black/50 text-white"
+                  }`}
                 >
                   ×
                 </button>
@@ -152,7 +163,9 @@ export default function EditProfileScreen() {
             {profile.media.length < 9 && (
               <button
                 onClick={handlePhotoAdd}
-                className="w-full h-24 bg-zinc-800 rounded-lg flex items-center justify-center text-gray-400 hover:bg-zinc-700"
+                className={`w-full h-24 rounded-lg flex items-center justify-center transition ${
+                  theme === "light" ? "bg-zinc-200 hover:bg-zinc-300" : "bg-zinc-800 text-gray-400 hover:bg-zinc-700"
+                }`}
               >
                 + Додати фото
               </button>
@@ -168,7 +181,7 @@ export default function EditProfileScreen() {
             name="name"
             value={profile.name}
             onChange={handleChange}
-            className="w-full bg-zinc-800 px-4 py-3 rounded-xl placeholder-gray-400"
+            className={inputClass}
             placeholder="Ваше ім’я"
           />
         </div>
@@ -181,7 +194,7 @@ export default function EditProfileScreen() {
             name="age"
             value={profile.age}
             onChange={handleChange}
-            className="w-full bg-zinc-800 px-4 py-3 rounded-xl placeholder-gray-400"
+            className={inputClass}
             placeholder="Ваш вік"
           />
         </div>
@@ -194,7 +207,7 @@ export default function EditProfileScreen() {
             value={profile.bio}
             onChange={handleChange}
             maxLength={500}
-            className="w-full bg-zinc-800 px-4 py-3 rounded-xl placeholder-gray-400 resize-none h-24"
+            className={`${inputClass} resize-none h-24`}
             placeholder="Опишіть себе..."
           />
         </div>
@@ -207,7 +220,7 @@ export default function EditProfileScreen() {
             name="photo"
             value={profile.photo}
             onChange={handleChange}
-            className="w-full bg-zinc-800 px-4 py-3 rounded-xl placeholder-gray-400"
+            className={inputClass}
             placeholder="https://..."
           />
         </div>
@@ -331,7 +344,7 @@ export default function EditProfileScreen() {
               type="text"
               value={profile.moreAboutMe.education}
               onChange={(e) => handleNestedChange("moreAboutMe", "education", e.target.value)}
-              className="w-full bg-zinc-800 px-4 py-3 rounded-xl placeholder-gray-400"
+              className={inputClass}
               placeholder="Ваша освіта"
             />
           </div>
@@ -343,7 +356,7 @@ export default function EditProfileScreen() {
               type="text"
               value={profile.moreAboutMe.loveStyle}
               onChange={(e) => handleNestedChange("moreAboutMe", "loveStyle", e.target.value)}
-              className="w-full bg-zinc-800 px-4 py-3 rounded-xl placeholder-gray-400"
+              className={inputClass}
               placeholder="Ваш стиль кохання"
             />
           </div>
@@ -425,7 +438,7 @@ export default function EditProfileScreen() {
               name="jobTitle"
               value={profile.jobTitle}
               onChange={handleChange}
-              className="w-full bg-zinc-800 px-4 py-3 rounded-xl placeholder-gray-400"
+              className={inputClass}
               placeholder="Наприклад: Дизайнер"
             />
           </div>
@@ -437,7 +450,7 @@ export default function EditProfileScreen() {
               name="company"
               value={profile.company}
               onChange={handleChange}
-              className="w-full bg-zinc-800 px-4 py-3 rounded-xl placeholder-gray-400"
+              className={inputClass}
               placeholder="Де працюєте?"
             />
           </div>
@@ -449,7 +462,7 @@ export default function EditProfileScreen() {
               name="school"
               value={profile.school}
               onChange={handleChange}
-              className="w-full bg-zinc-800 px-4 py-3 rounded-xl placeholder-gray-400"
+              className={inputClass}
               placeholder="Наприклад: ЛНУ ім. Франка"
             />
           </div>
@@ -461,7 +474,7 @@ export default function EditProfileScreen() {
               name="location"
               value={profile.location}
               onChange={handleChange}
-              className="w-full bg-zinc-800 px-4 py-3 rounded-xl placeholder-gray-400"
+              className={inputClass}
               placeholder="Місто, село..."
             />
           </div>
@@ -505,7 +518,7 @@ export default function EditProfileScreen() {
             name="height"
             value={profile.height}
             onChange={handleChange}
-            className="w-full bg-zinc-800 px-4 py-3 rounded-xl placeholder-gray-400"
+            className={inputClass}
             placeholder="Наприклад, 180"
           />
         </div>
@@ -568,7 +581,7 @@ export default function EditProfileScreen() {
               name="gender"
               value={profile.gender}
               onChange={handleChange}
-              className="w-full bg-zinc-800 text-white px-4 py-3 rounded-xl"
+              className={inputClass}
             >
               <option value="">Оберіть стать</option>
               <option value="Чоловік">Чоловік</option>
@@ -584,7 +597,7 @@ export default function EditProfileScreen() {
               name="orientation"
               value={profile.orientation}
               onChange={handleChange}
-              className="w-full bg-zinc-800 text-white px-4 py-3 rounded-xl"
+              className={inputClass}
             >
               <option value="">Оберіть орієнтацію</option>
               <option value="Гетеросексуальна">Гетеросексуальна</option>

--- a/src/MatchesScreen.jsx
+++ b/src/MatchesScreen.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import { useTheme } from "./ThemeContext";
 
 export default function MatchesScreen() {
   const [searchTerm, setSearchTerm] = useState("");
+  const { theme } = useTheme();
 
   const newMatches = [
     {
@@ -44,14 +46,20 @@ export default function MatchesScreen() {
   );
 
   return (
-    <div className="w-[360px] h-[800px] mx-auto p-4 bg-black text-white rounded-2xl shadow-xl flex flex-col space-y-4">
+    <div
+      className={`w-[360px] h-[800px] mx-auto p-4 rounded-2xl shadow-xl flex flex-col space-y-4 transition-colors duration-300 ${
+        theme === "light" ? "bg-warm text-black" : "bg-darkbg text-textwarm"
+      }`}
+    >
       {/* Пошук */}
       <input
         type="text"
         placeholder="Пошук..."
         value={searchTerm}
         onChange={(e) => setSearchTerm(e.target.value)}
-        className="w-full px-4 py-2 rounded-xl bg-zinc-800 placeholder-gray-400 text-white focus:outline-none"
+        className={`w-full px-4 py-2 rounded-xl placeholder-gray-400 focus:outline-none ${
+          theme === "light" ? "bg-white text-black" : "bg-zinc-800 text-white"
+        }`}
       />
 
       {/* Нові пари */}
@@ -61,7 +69,9 @@ export default function MatchesScreen() {
           {newMatches.map(match => (
             <div
               key={match.id}
-              className="min-w-[120px] flex-shrink-0 rounded-xl overflow-hidden bg-zinc-800"
+              className={`min-w-[120px] flex-shrink-0 rounded-xl overflow-hidden ${
+                theme === "light" ? "bg-zinc-200" : "bg-zinc-800"
+              }`}
             >
               <img src={match.photo} alt={match.name} className="w-full h-48 object-cover" />
               <p className="text-center py-2">{match.name}</p>
@@ -76,7 +86,11 @@ export default function MatchesScreen() {
         <div className="space-y-3">
           {filteredMessages.map(msg => (
             <Link to={`/chat/${msg.id}`} key={msg.id} className="block">
-              <div className="flex items-center gap-3 hover:bg-zinc-900 p-2 rounded-lg transition">
+              <div
+                className={`flex items-center gap-3 p-2 rounded-lg transition hover:bg-opacity-70 ${
+                  theme === "light" ? "hover:bg-zinc-200" : "hover:bg-zinc-900"
+                }`}
+              >
                 <img src={msg.avatar} alt={msg.name} className="w-10 h-10 rounded-full" />
                 <div className="flex-1">
                   <div className="flex justify-between items-center">

--- a/src/SwipeScreen.jsx
+++ b/src/SwipeScreen.jsx
@@ -21,7 +21,11 @@ export default function SwipeScreen() {
   ];
 
   return (
-    <div className="w-[360px] h-[800px] bg-white text-black dark:bg-black dark:text-white mx-auto flex flex-col justify-between p-4 rounded-2xl shadow-xl">
+    <div
+      className={`w-[360px] h-[800px] mx-auto flex flex-col justify-between p-4 rounded-2xl shadow-xl transition-colors duration-300 ${
+        theme === "light" ? "bg-warm text-black" : "bg-darkbg text-textwarm"
+      }`}
+    >
       {/* Profile card */}
       <div className="flex-1 flex flex-col items-center justify-center space-y-4">
         <img

--- a/src/UserProfileScreen.jsx
+++ b/src/UserProfileScreen.jsx
@@ -15,7 +15,16 @@ export default function UserProfileScreen() {
 
   if (!profile) {
     return (
-      <div className="text-center p-6 text-white">Завантаження профілю...</div>
+      <div
+        className={`w-full max-w-md mx-auto p-6 text-center space-y-4 transition-colors duration-300 ${
+          theme === "light" ? "bg-warm text-black" : "bg-darkbg text-textwarm"
+        }`}
+      >
+        <p>Профіль не заповнений.</p>
+        <Link to="/edit-profile" className="text-purple-500 underline">
+          Створити профіль
+        </Link>
+      </div>
     );
   }
 


### PR DESCRIPTION
## Summary
- show fallback message on profile page
- unify theme toggle in bottom navbar
- apply theme classes in `App` component
- support light/dark theme in chat, matches, swipe and edit profile screens

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684585acb53c833184e6844f1cf9821f