### PR TITLE
Adjust purple button brightness

### DIFF
--- a/src/ForgotPasswordScreen.jsx
+++ b/src/ForgotPasswordScreen.jsx
@@ -45,7 +45,7 @@ export default function ForgotPasswordScreen() {
           <button
             type="submit"
             className={`py-3 rounded-xl font-semibold transition w-full ${theme === "light"
-                ? "bg-pastelPurple text-textwarm hover:bg-purple-500"
+                ? "bg-pastelPurple text-white hover:bg-purple-400"
                 : "bg-purple-600 text-textwarm hover:bg-purple-700"
               }`}
           >

--- a/src/LogInScreen.jsx
+++ b/src/LogInScreen.jsx
@@ -54,7 +54,7 @@ export default function LogInScreen() {
           <button
             type="submit"
             className={`py-3 rounded-xl font-semibold transition w-full ${theme === "light"
-              ? "bg-pastelPurple text-textwarm hover:bg-[#b89ef7]"
+              ? "bg-pastelPurple text-white hover:bg-purple-400"
               : "bg-purple-600 text-textwarm hover:bg-purple-700"
               }`}
           >

--- a/src/SignUpScreen.jsx
+++ b/src/SignUpScreen.jsx
@@ -60,7 +60,7 @@ export default function SignUpScreen() {
           <button
             type="submit"
             className={`py-3 rounded-xl font-semibold transition w-full ${theme === "light"
-              ? "bg-pastelPurple text-textwarm hover:bg-[#b89ef7]"
+              ? "bg-pastelPurple text-white hover:bg-purple-400"
               : "bg-purple-600 text-textwarm hover:bg-purple-700"
               }`}
           >


### PR DESCRIPTION
## Summary
- tweak purple button color for sign up, login and forgot password screens

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458a627ccc8331a94078fc5410c12b