### PR TITLE
Fix theme toggles on remaining pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,7 @@ function AppContent() {
   const shouldShowNav = !hideNavOn.includes(location.pathname);
 
   return (
-    <div className="min-h-screen bg-black grid">
+    <div className="min-h-screen bg-warm text-black dark:bg-black dark:text-white grid">
       {/* iPhone 15 Pro Max frame */}
       {/* <div className="w-[430px] h-[932px] rounded-[38px] border-[12px] border-zinc-800 shadow-2xl overflow-hidden relative"> */}
       {/* Dynamic Island */}

--- a/src/BottomNavBar.jsx
+++ b/src/BottomNavBar.jsx
@@ -1,24 +1,9 @@
 import { NavLink } from "react-router-dom";
 import { FaHome, FaComment, FaUser, FaMoon, FaSun } from "react-icons/fa";
-import { useEffect, useState } from "react";
+import { useTheme } from "./ThemeContext";
 
 export default function BottomNavBar() {
-  const [isDark, setIsDark] = useState(true);
-
-  useEffect(() => {
-    document.documentElement.classList.add("dark");
-  }, []);
-
-  const toggleTheme = () => {
-    const html = document.documentElement;
-    if (html.classList.contains("dark")) {
-      html.classList.remove("dark");
-      setIsDark(false);
-    } else {
-      html.classList.add("dark");
-      setIsDark(true);
-    }
-  };
+  const { theme, toggleTheme } = useTheme();
 
   const navItemClass = ({ isActive }) =>
     `flex flex-col items-center text-xs gap-1 transition duration-200 
@@ -45,7 +30,7 @@ export default function BottomNavBar() {
         className="absolute top-1 left-2 text-sm opacity-60 hover:opacity-100 transition"
         aria-label="Toggle Theme"
       >
-        {isDark ? <FaSun size={16} /> : <FaMoon size={16} />}
+        {theme === "light" ? <FaMoon size={16} /> : <FaSun size={16} />}
       </button>
     </div>
   );

--- a/src/ChatConversationScreen.jsx
+++ b/src/ChatConversationScreen.jsx
@@ -1,11 +1,13 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useRef, useState } from "react";
+import { useTheme } from "./ThemeContext";
 
 export default function ChatConversationScreen() {
   const { userId } = useParams();
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState("");
   const chatRef = useRef(null);
+  const { theme } = useTheme();
 
   const partner = {
     id: userId,
@@ -69,10 +71,19 @@ export default function ChatConversationScreen() {
   };
 
   return (
-    <div className="w-full max-w-[430px] h-[800px] mx-auto bg-black text-white p-4 rounded-2xl shadow-xl flex flex-col">
+    <div
+      className={`w-full max-w-[430px] h-[800px] mx-auto p-4 rounded-2xl shadow-xl flex flex-col transition-all duration-300 ${
+        theme === "light" ? "bg-warm text-black" : "bg-darkbg text-textwarm"
+      }`}
+    >
       <h2 className="text-lg font-bold mb-4">Чат з {partner.name}</h2>
 
-      <div ref={chatRef} className="flex-1 bg-zinc-800 rounded-lg p-4 overflow-y-auto space-y-4">
+      <div
+        ref={chatRef}
+        className={`flex-1 rounded-lg p-4 overflow-y-auto space-y-4 ${
+          theme === "light" ? "bg-zinc-200" : "bg-zinc-800"
+        }`}
+      >
         {messages.map(msg => (
           <div key={msg.id} className={`flex ${msg.side === "right" ? "justify-end" : "justify-start"}`}>
             <div className={`flex items-end gap-2 max-w-[70%] ${msg.side === "right" ? "flex-row-reverse" : ""}`}>
@@ -80,7 +91,11 @@ export default function ChatConversationScreen() {
                 <img src={msg.avatar} alt={msg.from} className="w-8 h-8 rounded-full" />
               )}
               <div>
-                <div className="bg-zinc-900 px-4 py-2 rounded-xl text-sm text-white">
+                <div
+                  className={`px-4 py-2 rounded-xl text-sm ${
+                    theme === "light" ? "bg-zinc-300 text-black" : "bg-zinc-900 text-white"
+                  }`}
+                >
                   {msg.text}
                 </div>
                 <div className="text-xs text-gray-500 mt-1 text-right">{msg.time}</div>
@@ -96,7 +111,9 @@ export default function ChatConversationScreen() {
           value={input}
           onChange={e => setInput(e.target.value)}
           placeholder="Напишіть повідомлення..."
-          className="flex-1 bg-zinc-900 text-white px-4 py-2 rounded-lg focus:outline-none"
+          className={`flex-1 px-4 py-2 rounded-lg focus:outline-none transition ${
+            theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-white"
+          }`}
         />
         <button
           onClick={handleSend}

--- a/src/EditProfileScreen.jsx
+++ b/src/EditProfileScreen.jsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useTheme } from "./ThemeContext";
 
 export default function EditProfileScreen() {
   const navigate = useNavigate();
+  const { theme } = useTheme();
   const popularInterests = [
     "Подорожі", "Музика", "Фільми", "Спорт", "Йога",
     "Танці", "Кавові побачення", "Відеоігри", "Меми",
@@ -127,7 +129,11 @@ export default function EditProfileScreen() {
   };
 
   return (
-    <div className="w-full max-w-md mx-auto bg-black text-white min-h-screen">
+    <div
+      className={`w-full max-w-md mx-auto min-h-screen transition-all duration-300 ${
+        theme === "light" ? "bg-warm text-black" : "bg-darkbg text-textwarm"
+      }`}
+    >
       <div className="p-6 space-y-4 overflow-y-auto pb-24">
         <h2 className="text-xl font-bold text-center">Редагування профілю</h2>
 

--- a/src/MatchesScreen.jsx
+++ b/src/MatchesScreen.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import { useTheme } from "./ThemeContext";
 
 export default function MatchesScreen() {
   const [searchTerm, setSearchTerm] = useState("");
+  const { theme } = useTheme();
 
   const newMatches = [
     {
@@ -44,14 +46,20 @@ export default function MatchesScreen() {
   );
 
   return (
-    <div className="w-[360px] h-[800px] mx-auto p-4 bg-black text-white rounded-2xl shadow-xl flex flex-col space-y-4">
+    <div
+      className={`w-[360px] h-[800px] mx-auto p-4 rounded-2xl shadow-xl flex flex-col space-y-4 transition-all duration-300 ${
+        theme === "light" ? "bg-warm text-black" : "bg-darkbg text-textwarm"
+      }`}
+    >
       {/* Пошук */}
       <input
         type="text"
         placeholder="Пошук..."
         value={searchTerm}
         onChange={(e) => setSearchTerm(e.target.value)}
-        className="w-full px-4 py-2 rounded-xl bg-zinc-800 placeholder-gray-400 text-white focus:outline-none"
+        className={`w-full px-4 py-2 rounded-xl placeholder-gray-400 focus:outline-none transition ${
+          theme === "light" ? "bg-white text-black" : "bg-zinc-800 text-white"
+        }`}
       />
 
       {/* Нові пари */}
@@ -61,7 +69,9 @@ export default function MatchesScreen() {
           {newMatches.map(match => (
             <div
               key={match.id}
-              className="min-w-[120px] flex-shrink-0 rounded-xl overflow-hidden bg-zinc-800"
+              className={`min-w-[120px] flex-shrink-0 rounded-xl overflow-hidden ${
+                theme === "light" ? "bg-[#f0e4d7]" : "bg-zinc-800"
+              }`}
             >
               <img src={match.photo} alt={match.name} className="w-full h-48 object-cover" />
               <p className="text-center py-2">{match.name}</p>
@@ -76,7 +86,11 @@ export default function MatchesScreen() {
         <div className="space-y-3">
           {filteredMessages.map(msg => (
             <Link to={`/chat/${msg.id}`} key={msg.id} className="block">
-              <div className="flex items-center gap-3 hover:bg-zinc-900 p-2 rounded-lg transition">
+              <div
+                className={`flex items-center gap-3 p-2 rounded-lg transition ${
+                  theme === "light" ? "hover:bg-zinc-100" : "hover:bg-zinc-900"
+                }`}
+              >
                 <img src={msg.avatar} alt={msg.name} className="w-10 h-10 rounded-full" />
                 <div className="flex-1">
                   <div className="flex justify-between items-center">

--- a/src/SwipeCard.jsx
+++ b/src/SwipeCard.jsx
@@ -1,7 +1,9 @@
 import TinderCard from "react-tinder-card";
 import { forwardRef } from "react";
+import { useTheme } from "./ThemeContext";
 
 const SwipeCard = forwardRef(({ name, age, about, photo, onSwipe }, ref) => {
+  const { theme } = useTheme();
   return (
     <TinderCard
       preventSwipe={["down"]}
@@ -9,8 +11,11 @@ const SwipeCard = forwardRef(({ name, age, about, photo, onSwipe }, ref) => {
       ref={ref}
       className="absolute"
     >
-      <div className="w-[320px] h-[500px] bg-zinc-800 text-white rounded-2xl shadow-lg overflow-hidden 
-        animate-fadeInUp transition-all duration-500">
+      <div
+        className={`w-[320px] h-[500px] rounded-2xl shadow-lg overflow-hidden animate-fadeInUp transition-all duration-500 ${
+          theme === "light" ? "bg-white text-black" : "bg-zinc-800 text-white"
+        }`}
+      >
         <img src={photo} alt={name} className="w-full h-2/3 object-cover" />
         <div className="p-4">
           <h2 className="text-xl font-bold">{name}, {age}</h2>


### PR DESCRIPTION
## Summary
- hook up ThemeContext in bottom nav and other screens
- add light and dark styles in chat, matches, profile editing, and swipe card
- use dark mode classes for main App container

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6845927825d08331bd81435704be915b