### PR TITLE
Fix language persistence

### DIFF
--- a/src/ForgotPasswordScreen.jsx
+++ b/src/ForgotPasswordScreen.jsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useTheme } from "./ThemeContext";
 import LanguageThemeSwitcher from "./LanguageThemeSwitcher";
+import { useLanguage } from "./LanguageContext";
 
 export default function ForgotPasswordScreen() {
-  const [language, setLanguage] = useState("ua");
+  const { language } = useLanguage();
   const { theme } = useTheme();
 
   const texts = {
@@ -58,7 +58,7 @@ export default function ForgotPasswordScreen() {
         </p>
       </div>
 
-      <LanguageThemeSwitcher language={language} setLanguage={setLanguage} />
+      <LanguageThemeSwitcher />
     </div>
   );
 }

--- a/src/LanguageContext.js
+++ b/src/LanguageContext.js
@@ -1,0 +1,26 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+const LanguageContext = createContext();
+
+export function LanguageProvider({ children }) {
+  const [language, setLanguage] = useState("ua");
+
+  useEffect(() => {
+    const saved = localStorage.getItem("language");
+    if (saved === "ua" || saved === "en") {
+      setLanguage(saved);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("language", language);
+  }, [language]);
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export const useLanguage = () => useContext(LanguageContext);

--- a/src/LanguageThemeSwitcher.jsx
+++ b/src/LanguageThemeSwitcher.jsx
@@ -1,8 +1,10 @@
 import { BsSun, BsMoon } from "react-icons/bs";
 import { useTheme } from "./ThemeContext";
+import { useLanguage } from "./LanguageContext";
 
-export default function LanguageThemeSwitcher({ language, setLanguage }) {
+export default function LanguageThemeSwitcher() {
   const { theme, toggleTheme } = useTheme();
+  const { language, setLanguage } = useLanguage();
 
   return (
     <div className="flex justify-center items-center gap-4 text-sm opacity-80 pt-4 pb-2">

--- a/src/LogInScreen.jsx
+++ b/src/LogInScreen.jsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useTheme } from "./ThemeContext";
 import LanguageThemeSwitcher from "./LanguageThemeSwitcher";
+import { useLanguage } from "./LanguageContext";
 import { FaApple, FaGoogle, FaFacebookF, FaInstagram } from "react-icons/fa";
 
 export default function LogInScreen() {
-  const [language, setLanguage] = useState("ua");
+  const { language } = useLanguage();
   const { theme } = useTheme();
 
   const texts = {
@@ -93,7 +93,7 @@ export default function LogInScreen() {
           </Link>
         </p>
       </div>
-      <LanguageThemeSwitcher language={language} setLanguage={setLanguage} />
+      <LanguageThemeSwitcher />
     </div>
   );
 }

--- a/src/SignUpScreen.jsx
+++ b/src/SignUpScreen.jsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useTheme } from "./ThemeContext";
 import LanguageThemeSwitcher from "./LanguageThemeSwitcher";
+import { useLanguage } from "./LanguageContext";
 import { FaApple, FaGoogle, FaFacebookF, FaInstagram } from "react-icons/fa";
 
 export default function SignUpScreen() {
-  const [language, setLanguage] = useState("ua");
+  const { language } = useLanguage();
   const { theme } = useTheme();
 
   const texts = {
@@ -96,10 +96,7 @@ export default function SignUpScreen() {
           </Link>
         </p>
       </div>
-      <LanguageThemeSwitcher
-        language={language}
-        setLanguage={setLanguage}
-      />
+      <LanguageThemeSwitcher />
     </div>
   );
 }

--- a/src/WelcomeScreen.jsx
+++ b/src/WelcomeScreen.jsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useTheme } from "./ThemeContext";
 import LanguageThemeSwitcher from "./LanguageThemeSwitcher";
+import { useLanguage } from "./LanguageContext";
 
 export default function WelcomeScreen() {
-  const [language, setLanguage] = useState("ua");
+  const { language } = useLanguage();
   const { theme } = useTheme();
 
   const texts = {
@@ -58,7 +58,7 @@ export default function WelcomeScreen() {
       </div>
 
       {/* Language and Theme Switcher */}
-      <LanguageThemeSwitcher language={language} setLanguage={setLanguage} />
+      <LanguageThemeSwitcher />
     </div>
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,15 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import { ThemeProvider } from './ThemeContext';
+import { LanguageProvider } from './LanguageContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <ThemeProvider>
-      <App />
+      <LanguageProvider>
+        <App />
+      </LanguageProvider>
     </ThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- store language in `LanguageProvider`
- share language state across pages in top-level context
- access language from `useLanguage` in screens and switcher
- wrap app in `LanguageProvider`

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68459b8bb47883319fb341840c1c5579