### PR TITLE
Use pastel purple in light mode

### DIFF
--- a/src/BottomNavBar.jsx
+++ b/src/BottomNavBar.jsx
@@ -6,8 +6,13 @@ export default function BottomNavBar() {
   const { theme, toggleTheme } = useTheme();
 
   const navItemClass = ({ isActive }) =>
-    `flex flex-col items-center text-xs gap-1 transition duration-200 
-     ${isActive ? "text-purple-500 scale-110" : "text-gray-500 dark:text-gray-400 hover:text-black dark:hover:text-white"}`;
+    `flex flex-col items-center text-xs gap-1 transition duration-200 ${
+      isActive
+        ? theme === "light"
+          ? "text-pastelPurple scale-110"
+          : "text-purple-500 scale-110"
+        : "text-gray-500 dark:text-gray-400 hover:text-black dark:hover:text-white"
+    }`;
 
   return (
     <div className="fixed bottom-0 left-0 right-0 bg-warm dark:bg-zinc-900 border-t border-zinc-300 dark:border-zinc-800 h-16 flex justify-around items-center text-black dark:text-white z-50">

--- a/src/ChatConversationScreen.jsx
+++ b/src/ChatConversationScreen.jsx
@@ -120,7 +120,11 @@ export default function ChatConversationScreen() {
         />
         <button
           onClick={handleSend}
-          className="bg-purple-600 px-4 py-2 rounded-lg hover:bg-purple-700 transition"
+          className={`px-4 py-2 rounded-lg transition ${
+            theme === "light"
+              ? "bg-pastelPurple text-white hover:bg-purple-400"
+              : "bg-purple-600 hover:bg-purple-700"
+          }`}
         >
           Надіслати
         </button>

--- a/src/EditProfileScreen.jsx
+++ b/src/EditProfileScreen.jsx
@@ -230,7 +230,9 @@ export default function EditProfileScreen() {
                   type="button"
                   onClick={() => toggleInterest(interest)}
                   className={`px-4 py-2 rounded-full text-sm border transition ${selected
-                    ? "bg-purple-600 border-purple-600 text-white"
+                    ? theme === "light"
+                      ? "bg-pastelPurple border-pastelPurple text-white"
+                      : "bg-purple-600 border-purple-600 text-white"
                     : "bg-zinc-800 border-zinc-700 text-gray-400 hover:bg-zinc-700"
                     }`}
                 >
@@ -259,7 +261,9 @@ export default function EditProfileScreen() {
                   type="button"
                   onClick={() => handleNestedChange("moreAboutMe", "zodiac", sign)}
                   className={`px-4 py-2 rounded-full text-sm border transition ${profile.moreAboutMe.zodiac === sign
-                    ? "bg-purple-600 border-purple-600 text-white"
+                    ? theme === "light"
+                      ? "bg-pastelPurple border-pastelPurple text-white"
+                      : "bg-purple-600 border-purple-600 text-white"
                     : "bg-zinc-800 border-zinc-700 text-gray-400 hover:bg-zinc-700"
                     }`}
                 >
@@ -281,7 +285,9 @@ export default function EditProfileScreen() {
                   type="button"
                   onClick={() => handleNestedChange("moreAboutMe", "familyPlans", option)}
                   className={`px-4 py-2 rounded-full text-sm border transition ${profile.moreAboutMe.familyPlans === option
-                    ? "bg-purple-600 border-purple-600 text-white"
+                    ? theme === "light"
+                      ? "bg-pastelPurple border-pastelPurple text-white"
+                      : "bg-purple-600 border-purple-600 text-white"
                     : "bg-zinc-800 border-zinc-700 text-gray-400 hover:bg-zinc-700"
                     }`}
                 >
@@ -301,7 +307,9 @@ export default function EditProfileScreen() {
                   type="button"
                   onClick={() => handleNestedChange("moreAboutMe", "personalityType", type)}
                   className={`px-4 py-2 rounded-full text-sm border transition ${profile.moreAboutMe.personalityType === type
-                    ? "bg-purple-600 border-purple-600 text-white"
+                    ? theme === "light"
+                      ? "bg-pastelPurple border-pastelPurple text-white"
+                      : "bg-purple-600 border-purple-600 text-white"
                     : "bg-zinc-800 border-zinc-700 text-gray-400 hover:bg-zinc-700"
                     }`}
                 >
@@ -321,7 +329,9 @@ export default function EditProfileScreen() {
                   type="button"
                   onClick={() => handleNestedChange("moreAboutMe", "communicationStyle", style)}
                   className={`px-4 py-2 rounded-full text-sm border transition ${profile.moreAboutMe.communicationStyle === style
-                    ? "bg-purple-600 border-purple-600 text-white"
+                    ? theme === "light"
+                      ? "bg-pastelPurple border-pastelPurple text-white"
+                      : "bg-purple-600 border-purple-600 text-white"
                     : "bg-zinc-800 border-zinc-700 text-gray-400 hover:bg-zinc-700"
                     }`}
                 >
@@ -410,7 +420,9 @@ export default function EditProfileScreen() {
                         handleNestedChange("lifestyle", key, option)
                       }
                       className={`px-4 py-2 rounded-full text-sm border transition ${selected
-                        ? "bg-purple-600 border-purple-600 text-white"
+                        ? theme === "light"
+                          ? "bg-pastelPurple border-pastelPurple text-white"
+                          : "bg-purple-600 border-purple-600 text-white"
                         : "bg-zinc-800 border-zinc-700 text-gray-400 hover:bg-zinc-700"
                         }`}
                     >
@@ -493,7 +505,9 @@ export default function EditProfileScreen() {
                   type="button"
                   onClick={() => handleChange({ target: { name: "relationshipGoal", value: option } })}
                   className={`px-4 py-2 rounded-full text-sm border transition ${selected
-                    ? "bg-purple-600 border-purple-600 text-white"
+                    ? theme === "light"
+                      ? "bg-pastelPurple border-pastelPurple text-white"
+                      : "bg-purple-600 border-purple-600 text-white"
                     : "bg-zinc-800 border-zinc-700 text-gray-400 hover:bg-zinc-700"
                     }`}
                 >
@@ -555,7 +569,9 @@ export default function EditProfileScreen() {
                     });
                   }}
                   className={`px-4 py-2 rounded-full text-sm border transition ${selected
-                    ? "bg-purple-600 border-purple-600 text-white"
+                    ? theme === "light"
+                      ? "bg-pastelPurple border-pastelPurple text-white"
+                      : "bg-purple-600 border-purple-600 text-white"
                     : "bg-zinc-800 border-zinc-700 text-gray-400 hover:bg-zinc-700"
                     }`}
                 >
@@ -638,7 +654,7 @@ export default function EditProfileScreen() {
                 max="100"
                 value={profile.maxDistance}
                 onChange={handleChange}
-                className="w-full accent-purple-600"
+                className={`w-full ${theme === "light" ? "accent-pastelPurple" : "accent-purple-600"}`}
               />
               <p className="text-xs text-gray-400 mt-1">
                 {profile.maxDistance} км
@@ -652,7 +668,11 @@ export default function EditProfileScreen() {
         {/* Кнопка */}
         <button
           onClick={handleSave}
-          className="w-full bg-purple-600 py-3 rounded-xl font-semibold hover:bg-purple-700 transition mt-6"
+          className={`w-full py-3 rounded-xl font-semibold transition mt-6 ${
+            theme === "light"
+              ? "bg-pastelPurple text-white hover:bg-purple-400"
+              : "bg-purple-600 hover:bg-purple-700"
+          }`}
         >
           Зберегти
         </button>

--- a/src/LanguageThemeSwitcher.jsx
+++ b/src/LanguageThemeSwitcher.jsx
@@ -24,7 +24,9 @@ export default function LanguageThemeSwitcher() {
       <span className="mx-1">|</span>
       <button
         onClick={toggleTheme}
-        className="text-lg hover:text-purple-500 transition"
+        className={`text-lg transition ${
+          theme === "light" ? "hover:text-pastelPurple" : "hover:text-purple-500"
+        }`}
       >
         {theme === "light" ? <BsMoon /> : <BsSun />}
       </button>

--- a/src/SwipeScreen.jsx
+++ b/src/SwipeScreen.jsx
@@ -40,7 +40,13 @@ export default function SwipeScreen() {
         <button className="border border-red-500 text-red-500 p-4 rounded-full hover:bg-red-500/10 transition">
           <FaTimes size={24} />
         </button>
-        <button className="border border-purple-500 text-purple-500 p-5 rounded-full hover:bg-purple-500/10 transition">
+        <button
+          className={`p-5 rounded-full transition border ${
+            theme === "light"
+              ? "border-pastelPurple text-pastelPurple hover:bg-pastelPurple/10"
+              : "border-purple-500 text-purple-500 hover:bg-purple-500/10"
+          }`}
+        >
           <FaHeart size={28} />
         </button>
         <button className="border border-yellow-600 text-yellow-600 p-4 rounded-full hover:bg-yellow-600/10 transition">


### PR DESCRIPTION
## Summary
- adjust purple button shades in ChatConversationScreen
- change heart button color in SwipeScreen for light mode
- update active item color in BottomNavBar
- tweak theme toggle hover color
- show pastel purple for selections and save button in EditProfileScreen

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a1af89308331ba46d77364b5cde1