### PR TITLE
Improve accessibility labels

### DIFF
--- a/src/BottomNavBar.jsx
+++ b/src/BottomNavBar.jsx
@@ -17,15 +17,15 @@ export default function BottomNavBar() {
   return (
     <div className="fixed bottom-0 left-0 right-0 bg-warm dark:bg-zinc-900 border-t border-zinc-300 dark:border-zinc-800 h-16 flex justify-around items-center text-black dark:text-white z-50">
 
-      <NavLink to="/swipe" className={navItemClass}>
+      <NavLink to="/swipe" className={navItemClass} aria-label="Swipe">
         <FaHome size={20} />
       </NavLink>
 
-      <NavLink to="/matches" className={navItemClass}>
+      <NavLink to="/matches" className={navItemClass} aria-label="Matches">
         <FaComment size={20} />
       </NavLink>
 
-      <NavLink to="/profile" className={navItemClass}>
+      <NavLink to="/profile" className={navItemClass} aria-label="Profile">
         <FaUser size={20} />
       </NavLink>
 

--- a/src/ChatConversationScreen.jsx
+++ b/src/ChatConversationScreen.jsx
@@ -114,6 +114,7 @@ export default function ChatConversationScreen() {
           value={input}
           onChange={e => setInput(e.target.value)}
           placeholder="Напишіть повідомлення..."
+          aria-label="Message"
           className={`flex-1 px-4 py-2 rounded-lg focus:outline-none transition ${
             theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-white"
           }`}

--- a/src/ForgotPasswordScreen.jsx
+++ b/src/ForgotPasswordScreen.jsx
@@ -39,6 +39,7 @@ export default function ForgotPasswordScreen() {
           <input
             type="email"
             placeholder={t.email}
+            aria-label={t.email}
             className={`px-4 py-3 rounded-xl focus:outline-none placeholder-gray-500 transition shadow-inner
               ${theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-textwarm"}`}
           />

--- a/src/LogInScreen.jsx
+++ b/src/LogInScreen.jsx
@@ -42,12 +42,14 @@ export default function LogInScreen() {
           <input
             type="email"
             placeholder={t.email}
+            aria-label={t.email}
             className={`px-4 py-3 rounded-xl focus:outline-none placeholder-gray-500 transition shadow-inner
             ${theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-textwarm"}`}
           />
           <input
             type="password"
             placeholder={t.password}
+            aria-label={t.password}
             className={`px-4 py-3 rounded-xl focus:outline-none placeholder-gray-500 transition shadow-inner
             ${theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-textwarm"}`}
           />

--- a/src/MatchesScreen.jsx
+++ b/src/MatchesScreen.jsx
@@ -51,6 +51,7 @@ export default function MatchesScreen() {
       <input
         type="text"
         placeholder="Пошук..."
+        aria-label="Search"
         value={searchTerm}
         onChange={(e) => setSearchTerm(e.target.value)}
         className={`w-full px-4 py-2 rounded-xl placeholder-gray-400 focus:outline-none transition ${

--- a/src/SignUpScreen.jsx
+++ b/src/SignUpScreen.jsx
@@ -42,18 +42,21 @@ export default function SignUpScreen() {
           <input
             type="email"
             placeholder={t.email}
+            aria-label={t.email}
             className={`px-4 py-3 rounded-xl focus:outline-none placeholder-gray-500 transition shadow-inner
             ${theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-textwarm"}`}
           />
           <input
             type="password"
             placeholder={t.password}
+            aria-label={t.password}
             className={`px-4 py-3 rounded-xl focus:outline-none placeholder-gray-500 transition shadow-inner
             ${theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-textwarm"}`}
           />
           <input
             type="password"
             placeholder={t.confirm}
+            aria-label={t.confirm}
             className={`px-4 py-3 rounded-xl focus:outline-none placeholder-gray-500 transition shadow-inner
             ${theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-textwarm"}`}
           />


### PR DESCRIPTION
## Summary
- add `aria-label` attributes for navigation links
- label login, signup, and forgot password inputs
- label chat message and matches search inputs

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845a409f7cc8331849be730e0cad930