### PR TITLE
Add React Native skeleton

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import { Text, View } from 'react-native';
+
+function WelcomeScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Welcome to CatchYou</Text>
+    </View>
+  );
+}
+
+const Stack = createStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Welcome" component={WelcomeScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "catchyou-mobile",
+    "slug": "catchyou-mobile",
+    "version": "1.0.0",
+    "sdkVersion": "53.0.0",
+    "platforms": ["ios", "android", "web"],
+    "entryPoint": "./App.js"
+  }
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "catchyou-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^53.0.11",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.79.3",
+    "react-native-web": "^0.19.0",
+    "@react-navigation/native": "^6.1.9",
+    "@react-navigation/stack": "^6.3.22"
+  }
+}


### PR DESCRIPTION
## Summary
- add `mobile` folder with Expo-based React Native skeleton
- provide basic App with a welcome screen and navigation

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845a888cdcc8331a0f097e08fc9363e