### PR TITLE
Improve accessibility labels

### DIFF
--- a/src/ChatConversationScreen.jsx
+++ b/src/ChatConversationScreen.jsx
@@ -109,12 +109,15 @@ export default function ChatConversationScreen() {
       </div>
 
       <div className="mt-4 flex gap-2">
+        <label htmlFor="chat-message" className="sr-only">
+          Message
+        </label>
         <input
+          id="chat-message"
           type="text"
           value={input}
           onChange={e => setInput(e.target.value)}
           placeholder="Напишіть повідомлення..."
-          aria-label="Message"
           className={`flex-1 px-4 py-2 rounded-lg focus:outline-none transition ${
             theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-white"
           }`}

--- a/src/ForgotPasswordScreen.jsx
+++ b/src/ForgotPasswordScreen.jsx
@@ -36,10 +36,13 @@ export default function ForgotPasswordScreen() {
         <p className="text-sm text-gray-400 dark:text-gray-500 text-center mt-1">{t.description}</p>
 
         <form className="w-full flex flex-col space-y-4 mt-12">
+          <label htmlFor="recovery-email" className="sr-only">
+            {t.email}
+          </label>
           <input
+            id="recovery-email"
             type="email"
             placeholder={t.email}
-            aria-label={t.email}
             className={`px-4 py-3 rounded-xl focus:outline-none placeholder-gray-500 transition shadow-inner
               ${theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-textwarm"}`}
           />

--- a/src/LanguageContext.js
+++ b/src/LanguageContext.js
@@ -14,6 +14,7 @@ export function LanguageProvider({ children }) {
 
   useEffect(() => {
     localStorage.setItem("language", language);
+    document.documentElement.lang = language;
   }, [language]);
 
   return (

--- a/src/LogInScreen.jsx
+++ b/src/LogInScreen.jsx
@@ -39,17 +39,23 @@ export default function LogInScreen() {
       <div className="flex flex-col w-full">
         <h2 className="text-2xl font-bold text-center mt-4 mb-6">{t.title}</h2>
         <form className="w-full flex flex-col space-y-4 mt-6">
+          <label htmlFor="login-email" className="sr-only">
+            {t.email}
+          </label>
           <input
+            id="login-email"
             type="email"
             placeholder={t.email}
-            aria-label={t.email}
             className={`px-4 py-3 rounded-xl focus:outline-none placeholder-gray-500 transition shadow-inner
             ${theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-textwarm"}`}
           />
+          <label htmlFor="login-password" className="sr-only">
+            {t.password}
+          </label>
           <input
+            id="login-password"
             type="password"
             placeholder={t.password}
-            aria-label={t.password}
             className={`px-4 py-3 rounded-xl focus:outline-none placeholder-gray-500 transition shadow-inner
             ${theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-textwarm"}`}
           />

--- a/src/MatchesScreen.jsx
+++ b/src/MatchesScreen.jsx
@@ -48,10 +48,13 @@ export default function MatchesScreen() {
       }`}
     >
       {/* Пошук */}
+      <label htmlFor="match-search" className="sr-only">
+        Search
+      </label>
       <input
+        id="match-search"
         type="text"
         placeholder="Пошук..."
-        aria-label="Search"
         value={searchTerm}
         onChange={(e) => setSearchTerm(e.target.value)}
         className={`w-full px-4 py-2 rounded-xl placeholder-gray-400 focus:outline-none transition ${

--- a/src/SignUpScreen.jsx
+++ b/src/SignUpScreen.jsx
@@ -39,24 +39,33 @@ export default function SignUpScreen() {
       <div className="flex flex-col w-full">
         <h2 className="text-2xl font-bold text-center mt-4 mb-6">{t.title}</h2>
         <form className="w-full flex flex-col space-y-4 mt-6">
+          <label htmlFor="signup-email" className="sr-only">
+            {t.email}
+          </label>
           <input
+            id="signup-email"
             type="email"
             placeholder={t.email}
-            aria-label={t.email}
             className={`px-4 py-3 rounded-xl focus:outline-none placeholder-gray-500 transition shadow-inner
             ${theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-textwarm"}`}
           />
+          <label htmlFor="signup-password" className="sr-only">
+            {t.password}
+          </label>
           <input
+            id="signup-password"
             type="password"
             placeholder={t.password}
-            aria-label={t.password}
             className={`px-4 py-3 rounded-xl focus:outline-none placeholder-gray-500 transition shadow-inner
             ${theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-textwarm"}`}
           />
+          <label htmlFor="signup-confirm" className="sr-only">
+            {t.confirm}
+          </label>
           <input
+            id="signup-confirm"
             type="password"
             placeholder={t.confirm}
-            aria-label={t.confirm}
             className={`px-4 py-3 rounded-xl focus:outline-none placeholder-gray-500 transition shadow-inner
             ${theme === "light" ? "bg-white text-black" : "bg-zinc-900 text-textwarm"}`}
           />


### PR DESCRIPTION
## Summary
- add hidden labels for signup form fields
- add hidden labels for login form fields
- add hidden label for password recovery form
- add hidden label for matches search field
- add hidden label for chat message field
- set document language attribute in LanguageContext

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845c0b85e188331b70a64699422a279