### PR TITLE
Add theme and language context to mobile

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -2,15 +2,21 @@ import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import WelcomeScreen from './screens/WelcomeScreen';
+import { ThemeProvider } from './context/ThemeContext';
+import { LanguageProvider } from './context/LanguageContext';
 
 const Stack = createStackNavigator();
 
 export default function App() {
   return (
-    <NavigationContainer>
-      <Stack.Navigator>
-        <Stack.Screen name="Welcome" component={WelcomeScreen} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <ThemeProvider>
+      <LanguageProvider>
+        <NavigationContainer>
+          <Stack.Navigator>
+            <Stack.Screen name="Welcome" component={WelcomeScreen} />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </LanguageProvider>
+    </ThemeProvider>
   );
 }

--- a/mobile/context/LanguageContext.js
+++ b/mobile/context/LanguageContext.js
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const LanguageContext = createContext();
+
+export function LanguageProvider({ children }) {
+  const [language, setLanguage] = useState('ua');
+
+  useEffect(() => {
+    AsyncStorage.getItem('language').then((saved) => {
+      if (saved === 'ua' || saved === 'en') {
+        setLanguage(saved);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    AsyncStorage.setItem('language', language);
+  }, [language]);
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export const useLanguage = () => useContext(LanguageContext);

--- a/mobile/context/ThemeContext.js
+++ b/mobile/context/ThemeContext.js
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const ThemeContext = createContext();
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState('dark');
+
+  useEffect(() => {
+    AsyncStorage.getItem('theme').then((saved) => {
+      if (saved === 'light' || saved === 'dark') {
+        setTheme(saved);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    AsyncStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export const useTheme = () => useContext(ThemeContext);

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -21,6 +21,7 @@
     "tailwindcss": "^4.1.8",
     "react-native-screens": "^4.11.1",
     "react-native-safe-area-context": "^5.4.1",
-    "react-native-gesture-handler": "^2.25.0"
+    "react-native-gesture-handler": "^2.25.0",
+    "@react-native-async-storage/async-storage": "^1.21.0"
   }
 }

--- a/mobile/screens/WelcomeScreen.js
+++ b/mobile/screens/WelcomeScreen.js
@@ -1,10 +1,43 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { useLanguage } from '../context/LanguageContext';
+import { useTheme } from '../context/ThemeContext';
 
 export default function WelcomeScreen() {
+  const { language, setLanguage } = useLanguage();
+  const { theme, toggleTheme } = useTheme();
+
+  const texts = {
+    ua: {
+      welcome: 'Ласкаво просимо до CatchYou',
+      ua: 'Українська',
+      en: 'English',
+      toggle: 'Змінити тему',
+    },
+    en: {
+      welcome: 'Welcome to CatchYou',
+      ua: 'Ukrainian',
+      en: 'English',
+      toggle: 'Toggle Theme',
+    },
+  };
+
+  const t = texts[language];
+
   return (
-    <View className="flex-1 items-center justify-center">
-      <Text>Welcome to CatchYou</Text>
+    <View className={`flex-1 items-center justify-center ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>
+      <Text className={`mb-4 text-lg ${theme === 'light' ? 'text-black' : 'text-white'}`}>{t.welcome}</Text>
+      <View className="flex-row space-x-4">
+        <TouchableOpacity onPress={() => setLanguage('ua')}>
+          <Text className={`underline ${language === 'ua' ? 'font-bold' : ''}`}>{t.ua}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={() => setLanguage('en')}>
+          <Text className={`underline ${language === 'en' ? 'font-bold' : ''}`}>{t.en}</Text>
+        </TouchableOpacity>
+      </View>
+      <TouchableOpacity onPress={toggleTheme} className="mt-4">
+        <Text className="text-blue-500">{t.toggle}</Text>
+      </TouchableOpacity>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- add ThemeContext and LanguageContext for React Native
- update WelcomeScreen to toggle language and theme
- wrap navigation with the new providers
- install AsyncStorage dependency for state persistence

## Testing
- `CI=true npm test --silent`
- `npm install --prefix mobile --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845e428ab64833190d48ea3adb6d6a9