### PR TITLE
Add mobile auth screens with theme and language support

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -5,6 +5,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import WelcomeScreen from './screens/WelcomeScreen';
 import LoginScreen from './screens/LoginScreen';
 import RegisterScreen from './screens/RegisterScreen';
+import ForgotPasswordScreen from './screens/ForgotPasswordScreen';
 import MatchesScreen from './screens/MatchesScreen';
 import ChatScreen from './screens/ChatScreen';
 import ProfileScreen from './screens/ProfileScreen';
@@ -43,6 +44,7 @@ export default function App() {
             <Stack.Screen name="Welcome" component={WelcomeScreen} />
             <Stack.Screen name="Login" component={LoginScreen} />
             <Stack.Screen name="Register" component={RegisterScreen} />
+            <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} />
             <Stack.Screen name="Home" component={HomeTabs} />
           </Stack.Navigator>
         </NavigationContainer>

--- a/mobile/components/LanguageThemeSwitcher.js
+++ b/mobile/components/LanguageThemeSwitcher.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { useLanguage } from '../context/LanguageContext';
+import { useTheme } from '../context/ThemeContext';
+
+export default function LanguageThemeSwitcher({ labels }) {
+  const { language, setLanguage } = useLanguage();
+  const { theme, toggleTheme } = useTheme();
+
+  const t = labels ? labels[language] : { ua: 'UA', en: 'EN', toggle: 'Toggle Theme' };
+
+  return (
+    <View className="items-center mt-6">
+      <View className="flex-row space-x-4">
+        <TouchableOpacity onPress={() => setLanguage('ua')}>
+          <Text className={`underline ${language === 'ua' ? 'font-bold' : ''} ${theme === 'light' ? 'text-black' : 'text-white'}`}>{t.ua}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={() => setLanguage('en')}>
+          <Text className={`underline ${language === 'en' ? 'font-bold' : ''} ${theme === 'light' ? 'text-black' : 'text-white'}`}>{t.en}</Text>
+        </TouchableOpacity>
+      </View>
+      <TouchableOpacity onPress={toggleTheme} className="mt-2">
+        <Text className="text-blue-500">{t.toggle}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/mobile/screens/ForgotPasswordScreen.js
+++ b/mobile/screens/ForgotPasswordScreen.js
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity } from 'react-native';
+import CustomButton from '../components/CustomButton';
+import LanguageThemeSwitcher from '../components/LanguageThemeSwitcher';
+import { useTheme } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
+
+export default function ForgotPasswordScreen({ navigation }) {
+  const { theme } = useTheme();
+  const { language } = useLanguage();
+  const [email, setEmail] = useState('');
+
+  const texts = {
+    ua: {
+      title: 'Відновлення пароля',
+      description: 'Введіть пошту для відновлення',
+      email: 'Електронна пошта',
+      submit: 'Відновити',
+      back: 'Назад до входу',
+    },
+    en: {
+      title: 'Password Recovery',
+      description: 'Enter your email and we\u2019ll send instructions',
+      email: 'Email',
+      submit: 'Recover',
+      back: 'Back to login',
+    },
+  };
+
+  const t = texts[language];
+
+  return (
+    <View className={`flex-1 items-center justify-center p-4 ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>
+      <Text className={`text-xl mb-2 ${theme === 'light' ? 'text-black' : 'text-white'}`}>{t.title}</Text>
+      <Text className="text-sm text-gray-500 mb-4">{t.description}</Text>
+      <TextInput
+        className="w-full border p-2 mb-4 rounded"
+        placeholder={t.email}
+        value={email}
+        onChangeText={setEmail}
+      />
+      <CustomButton title={t.submit} onPress={() => navigation.goBack()} />
+      <TouchableOpacity onPress={() => navigation.goBack()} className="mt-4">
+        <Text className="text-sm text-gray-500 underline">{t.back}</Text>
+      </TouchableOpacity>
+      <LanguageThemeSwitcher labels={{ ua: { ua: texts.ua.ua, en: texts.ua.en, toggle: texts.ua.toggle }, en: { ua: texts.en.ua, en: texts.en.en, toggle: texts.en.toggle } }} />
+    </View>
+  );
+}

--- a/mobile/screens/LoginScreen.js
+++ b/mobile/screens/LoginScreen.js
@@ -1,33 +1,82 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity } from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
 import CustomButton from '../components/CustomButton';
+import LanguageThemeSwitcher from '../components/LanguageThemeSwitcher';
 import { useTheme } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function LoginScreen({ navigation }) {
   const { theme } = useTheme();
+  const { language } = useLanguage();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const texts = {
+    ua: {
+      title: 'Увійти',
+      email: 'Електронна пошта',
+      password: 'Пароль',
+      submit: 'Увійти',
+      noAccount: 'Ще не маєте акаунту? Зареєструватися',
+      forgot: 'Забули пароль?',
+      or: 'Або увійти через',
+    },
+    en: {
+      title: 'Log In',
+      email: 'Email',
+      password: 'Password',
+      submit: 'Log In',
+      noAccount: "Don't have an account? Sign up",
+      forgot: 'Forgot password?',
+      or: 'Or continue with',
+    },
+  };
+
+  const t = texts[language];
+
+  const handleSubmit = () => {
+    if (!email.includes('@') || password.length === 0) {
+      setError(t.email);
+      return;
+    }
+    setError('');
+    navigation.replace('Home');
+  };
 
   return (
     <View className={`flex-1 items-center justify-center p-4 ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>
-      <Text className={`text-xl mb-4 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Log In</Text>
+      <Text className={`text-xl mb-4 ${theme === 'light' ? 'text-black' : 'text-white'}`}>{t.title}</Text>
+      {error ? <Text className="text-red-500 mb-2">{error}</Text> : null}
       <TextInput
         className="w-full border p-2 mb-3 rounded"
-        placeholder="Email"
+        placeholder={t.email}
         value={email}
         onChangeText={setEmail}
       />
       <TextInput
-        className="w-full border p-2 mb-6 rounded"
-        placeholder="Password"
+        className="w-full border p-2 mb-3 rounded"
+        placeholder={t.password}
         secureTextEntry
         value={password}
         onChangeText={setPassword}
       />
-      <CustomButton title="Submit" onPress={() => navigation.replace('Home')} />
-      <View className="mt-4">
-        <CustomButton title="Register" onPress={() => navigation.navigate('Register')} />
+      <CustomButton title={t.submit} onPress={handleSubmit} />
+      <TouchableOpacity onPress={() => navigation.navigate('ForgotPassword')} className="mt-2">
+        <Text className="text-blue-500 underline">{t.forgot}</Text>
+      </TouchableOpacity>
+      <View className="flex-row space-x-3 mt-6">
+        {[ 'apple', 'google', 'facebook', 'instagram' ].map((icon, i) => (
+          <TouchableOpacity key={i} className="p-3 rounded-full bg-gray-200">
+            <FontAwesome name={icon} size={20} color={theme === 'light' ? '#000' : '#fff'} />
+          </TouchableOpacity>
+        ))}
       </View>
+      <TouchableOpacity onPress={() => navigation.navigate('Register')} className="mt-4">
+        <Text className="text-sm text-gray-500 underline">{t.noAccount}</Text>
+      </TouchableOpacity>
+      <LanguageThemeSwitcher labels={{ ua: { ua: texts.ua.ua, en: texts.ua.en, toggle: texts.ua.toggle }, en: { ua: texts.en.ua, en: texts.en.en, toggle: texts.en.toggle } }} />
     </View>
   );
 }

--- a/mobile/screens/RegisterScreen.js
+++ b/mobile/screens/RegisterScreen.js
@@ -1,33 +1,77 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity } from 'react-native';
 import CustomButton from '../components/CustomButton';
+import LanguageThemeSwitcher from '../components/LanguageThemeSwitcher';
 import { useTheme } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function RegisterScreen({ navigation }) {
   const { theme } = useTheme();
+  const { language } = useLanguage();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState('');
+
+  const texts = {
+    ua: {
+      title: 'Реєстрація',
+      email: 'Електронна пошта',
+      password: 'Пароль',
+      confirm: 'Підтвердіть пароль',
+      submit: 'Зареєструватися',
+      haveAccount: 'Вже маєте акаунт? Увійти',
+    },
+    en: {
+      title: 'Sign Up',
+      email: 'Email',
+      password: 'Password',
+      confirm: 'Confirm Password',
+      submit: 'Register',
+      haveAccount: 'Already have an account? Log in',
+    },
+  };
+
+  const t = texts[language];
+
+  const handleSubmit = () => {
+    if (!email.includes('@') || password !== confirm) {
+      setError(t.email);
+      return;
+    }
+    setError('');
+    navigation.replace('Home');
+  };
 
   return (
     <View className={`flex-1 items-center justify-center p-4 ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>
-      <Text className={`text-xl mb-4 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Register</Text>
+      <Text className={`text-xl mb-4 ${theme === 'light' ? 'text-black' : 'text-white'}`}>{t.title}</Text>
+      {error ? <Text className="text-red-500 mb-2">{error}</Text> : null}
       <TextInput
         className="w-full border p-2 mb-3 rounded"
-        placeholder="Email"
+        placeholder={t.email}
         value={email}
         onChangeText={setEmail}
       />
       <TextInput
-        className="w-full border p-2 mb-6 rounded"
-        placeholder="Password"
+        className="w-full border p-2 mb-3 rounded"
+        placeholder={t.password}
         secureTextEntry
         value={password}
         onChangeText={setPassword}
       />
-      <CustomButton title="Sign Up" onPress={() => navigation.replace('Home')} />
-      <View className="mt-4">
-        <CustomButton title="Back to Login" onPress={() => navigation.goBack()} />
-      </View>
+      <TextInput
+        className="w-full border p-2 mb-6 rounded"
+        placeholder={t.confirm}
+        secureTextEntry
+        value={confirm}
+        onChangeText={setConfirm}
+      />
+      <CustomButton title={t.submit} onPress={handleSubmit} />
+      <TouchableOpacity onPress={() => navigation.goBack()} className="mt-4">
+        <Text className="text-sm text-gray-500 underline">{t.haveAccount}</Text>
+      </TouchableOpacity>
+      <LanguageThemeSwitcher labels={{ ua: { ua: texts.ua.ua, en: texts.ua.en, toggle: texts.ua.toggle }, en: { ua: texts.en.ua, en: texts.en.en, toggle: texts.en.toggle } }} />
     </View>
   );
 }

--- a/mobile/screens/WelcomeScreen.js
+++ b/mobile/screens/WelcomeScreen.js
@@ -1,12 +1,13 @@
 import React from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text } from 'react-native';
 import CustomButton from '../components/CustomButton';
+import LanguageThemeSwitcher from '../components/LanguageThemeSwitcher';
 import { useLanguage } from '../context/LanguageContext';
 import { useTheme } from '../context/ThemeContext';
 
 export default function WelcomeScreen({ navigation }) {
-  const { language, setLanguage } = useLanguage();
-  const { theme, toggleTheme } = useTheme();
+  const { language } = useLanguage();
+  const { theme } = useTheme();
 
   const texts = {
     ua: {
@@ -28,17 +29,7 @@ export default function WelcomeScreen({ navigation }) {
   return (
     <View className={`flex-1 items-center justify-center ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>
       <Text className={`mb-4 text-lg ${theme === 'light' ? 'text-black' : 'text-white'}`}>{t.welcome}</Text>
-      <View className="flex-row space-x-4">
-        <TouchableOpacity onPress={() => setLanguage('ua')}>
-          <Text className={`underline ${language === 'ua' ? 'font-bold' : ''}`}>{t.ua}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity onPress={() => setLanguage('en')}>
-          <Text className={`underline ${language === 'en' ? 'font-bold' : ''}`}>{t.en}</Text>
-        </TouchableOpacity>
-      </View>
-      <TouchableOpacity onPress={toggleTheme} className="mt-4">
-        <Text className="text-blue-500">{t.toggle}</Text>
-      </TouchableOpacity>
+      <LanguageThemeSwitcher labels={{ ua: { ua: texts.ua.ua, en: texts.ua.en, toggle: texts.ua.toggle }, en: { ua: texts.en.ua, en: texts.en.en, toggle: texts.en.toggle } }} />
       <View className="mt-6">
         <CustomButton title="Get Started" onPress={() => navigation.navigate('Login')} />
       </View>


### PR DESCRIPTION
## Summary
- add LanguageThemeSwitcher component for React Native app
- enhance WelcomeScreen to use shared switcher
- update LoginScreen with translations, validation, social buttons
- update RegisterScreen with confirm password and i18n
- add ForgotPasswordScreen to mobile
- wire new screen in App navigator

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6845e7ef67408331955072e1951d6021