### PR TITLE
Add profile editing to mobile app

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -10,6 +10,7 @@ import MatchesScreen from './screens/MatchesScreen';
 import ChatScreen from './screens/ChatScreen';
 import ProfileScreen from './screens/ProfileScreen';
 import SettingsScreen from './screens/SettingsScreen';
+import EditProfileScreen from './screens/EditProfileScreen';
 import { ThemeProvider } from './context/ThemeContext';
 import { LanguageProvider } from './context/LanguageContext';
 
@@ -46,6 +47,7 @@ export default function App() {
             <Stack.Screen name="Register" component={RegisterScreen} />
             <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} />
             <Stack.Screen name="Home" component={HomeTabs} />
+            <Stack.Screen name="EditProfile" component={EditProfileScreen} />
           </Stack.Navigator>
         </NavigationContainer>
       </LanguageProvider>

--- a/mobile/screens/EditProfileScreen.js
+++ b/mobile/screens/EditProfileScreen.js
@@ -1,0 +1,223 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, ScrollView, TouchableOpacity, Image, Switch } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useTheme } from '../context/ThemeContext';
+
+export default function EditProfileScreen({ navigation }) {
+  const { theme } = useTheme();
+  const defaultProfile = {
+    name: '',
+    age: '',
+    bio: '',
+    photos: [],
+    interests: [],
+    relationshipGoal: '',
+    height: '',
+    languages: [],
+    gender: '',
+    orientation: '',
+    job: '',
+    education: '',
+    hideAge: false,
+    hideDistance: false,
+  };
+
+  const [profile, setProfile] = useState(defaultProfile);
+  const popularInterests = ['Подорожі', 'Музика', 'Фільми', 'Спорт', 'Йога', 'Танці', 'Кавові побачення', 'Відеоігри', 'Меми', 'Книги'];
+  const goals = ['Серйозні', 'Дружба', 'Флірт', 'Невизначено', 'Відкриті стосунки', 'Шлюб'];
+  const langs = ['Українська', 'Англійська', 'Польська', 'Німецька', 'Французька'];
+
+  useEffect(() => {
+    AsyncStorage.getItem('userProfile').then((data) => {
+      if (data) {
+        setProfile({ ...defaultProfile, ...JSON.parse(data) });
+      }
+    });
+  }, []);
+
+  const updateField = (name, value) => {
+    setProfile((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const toggleArrayValue = (key, value, limit) => {
+    setProfile((prev) => {
+      const exists = prev[key].includes(value);
+      if (exists) {
+        return { ...prev, [key]: prev[key].filter((v) => v !== value) };
+      }
+      if (prev[key].length < limit) {
+        return { ...prev, [key]: [...prev[key], value] };
+      }
+      return prev;
+    });
+  };
+
+  const addPhoto = () => {
+    if (profile.photos.length >= 9) return;
+    if (profile.tempPhoto?.trim()) {
+      setProfile((prev) => ({
+        ...prev,
+        photos: [...prev.photos, prev.tempPhoto.trim()],
+        tempPhoto: '',
+      }));
+    }
+  };
+
+  const removePhoto = (idx) => {
+    setProfile((prev) => ({
+      ...prev,
+      photos: prev.photos.filter((_, i) => i !== idx),
+    }));
+  };
+
+  const saveProfile = async () => {
+    await AsyncStorage.setItem('userProfile', JSON.stringify(profile));
+    navigation.goBack();
+  };
+
+  return (
+    <ScrollView className={`flex-1 p-4 ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>\
+      <Text className={`text-xl font-bold mb-4 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Редагувати профіль</Text>
+
+      <Text className={`mb-1 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Фото (до 9)</Text>
+      <View className="flex-row flex-wrap mb-4">
+        {profile.photos.map((p, idx) => (
+          <TouchableOpacity key={idx} onPress={() => removePhoto(idx)} className="mr-2 mb-2">
+            <Image source={{ uri: p }} className="w-20 h-20 rounded" />
+          </TouchableOpacity>
+        ))}
+      </View>
+      {profile.photos.length < 9 && (
+        <View className="flex-row items-center mb-4">
+          <TextInput
+            placeholder="https://..."
+            value={profile.tempPhoto || ''}
+            onChangeText={(v) => updateField('tempPhoto', v)}
+            className="border flex-1 mr-2 p-2 rounded"
+          />
+          <TouchableOpacity onPress={addPhoto} className="bg-blue-500 p-3 rounded">
+            <Text className="text-white">Add</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      <Text className={`mb-1 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Ім'я</Text>
+      <TextInput
+        value={profile.name}
+        onChangeText={(v) => updateField('name', v)}
+        className="border p-2 rounded mb-4"
+      />
+
+      <Text className={`mb-1 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Вік</Text>
+      <TextInput
+        value={profile.age}
+        onChangeText={(v) => updateField('age', v)}
+        keyboardType="numeric"
+        className="border p-2 rounded mb-4"
+      />
+
+      <Text className={`mb-1 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Біо (до 500 символів)</Text>
+      <TextInput
+        value={profile.bio}
+        onChangeText={(v) => updateField('bio', v)}
+        multiline
+        maxLength={500}
+        className="border p-2 rounded mb-4 h-24"
+      />
+
+      <Text className={`mb-1 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Інтереси (до 10)</Text>
+      <View className="flex-row flex-wrap mb-4">
+        {popularInterests.map((int) => {
+          const selected = profile.interests.includes(int);
+          return (
+            <TouchableOpacity
+              key={int}
+              onPress={() => toggleArrayValue('interests', int, 10)}
+              className={`px-3 py-1 mr-2 mb-2 rounded-full border ${selected ? 'bg-blue-500 border-blue-500' : ''}`}
+            >
+              <Text className={`${theme === 'light' ? 'text-black' : 'text-white'}`}>{int}</Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      <Text className={`mb-1 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Ціль стосунків</Text>
+      <View className="flex-row flex-wrap mb-4">
+        {goals.map((g) => (
+          <TouchableOpacity
+            key={g}
+            onPress={() => updateField('relationshipGoal', g)}
+            className={`px-3 py-1 mr-2 mb-2 rounded-full border ${profile.relationshipGoal === g ? 'bg-blue-500 border-blue-500' : ''}`}
+          >
+            <Text className={`${theme === 'light' ? 'text-black' : 'text-white'}`}>{g}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <Text className={`mb-1 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Зріст</Text>
+      <TextInput
+        value={profile.height}
+        onChangeText={(v) => updateField('height', v)}
+        keyboardType="numeric"
+        className="border p-2 rounded mb-4"
+      />
+
+      <Text className={`mb-1 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Мови</Text>
+      <View className="flex-row flex-wrap mb-4">
+        {langs.map((l) => {
+          const selected = profile.languages.includes(l);
+          return (
+            <TouchableOpacity
+              key={l}
+              onPress={() => toggleArrayValue('languages', l, 5)}
+              className={`px-3 py-1 mr-2 mb-2 rounded-full border ${selected ? 'bg-blue-500 border-blue-500' : ''}`}
+            >
+              <Text className={`${theme === 'light' ? 'text-black' : 'text-white'}`}>{l}</Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      <Text className={`mb-1 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Стать</Text>
+      <TextInput
+        value={profile.gender}
+        onChangeText={(v) => updateField('gender', v)}
+        className="border p-2 rounded mb-4"
+      />
+
+      <Text className={`mb-1 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Орієнтація</Text>
+      <TextInput
+        value={profile.orientation}
+        onChangeText={(v) => updateField('orientation', v)}
+        className="border p-2 rounded mb-4"
+      />
+
+      <Text className={`mb-1 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Робота</Text>
+      <TextInput
+        value={profile.job}
+        onChangeText={(v) => updateField('job', v)}
+        className="border p-2 rounded mb-4"
+      />
+
+      <Text className={`mb-1 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Освіта</Text>
+      <TextInput
+        value={profile.education}
+        onChangeText={(v) => updateField('education', v)}
+        className="border p-2 rounded mb-4"
+      />
+
+      <View className="flex-row items-center mb-4">
+        <Text className={`mr-2 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Приховати вік</Text>
+        <Switch value={profile.hideAge} onValueChange={(v) => updateField('hideAge', v)} />
+      </View>
+      <View className="flex-row items-center mb-4">
+        <Text className={`mr-2 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Приховати відстань</Text>
+        <Switch value={profile.hideDistance} onValueChange={(v) => updateField('hideDistance', v)} />
+      </View>
+
+      <TouchableOpacity onPress={saveProfile} className="bg-blue-500 p-3 rounded mb-10">
+        <Text className="text-white text-center">Зберегти</Text>
+      </TouchableOpacity>
+    </ScrollView>
+  );
+}

--- a/mobile/screens/ProfileScreen.js
+++ b/mobile/screens/ProfileScreen.js
@@ -1,12 +1,63 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Text, Image, ScrollView, TouchableOpacity } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useTheme } from '../context/ThemeContext';
 
-export default function ProfileScreen() {
+export default function ProfileScreen({ navigation }) {
   const { theme } = useTheme();
+  const [profile, setProfile] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const data = await AsyncStorage.getItem('userProfile');
+      if (data) {
+        setProfile(JSON.parse(data));
+      }
+    };
+    const unsubscribe = navigation.addListener('focus', load);
+    return unsubscribe;
+  }, [navigation]);
+
+  if (!profile) {
+    return (
+      <View className={`flex-1 items-center justify-center ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>\
+        <Text className={`${theme === 'light' ? 'text-black' : 'text-white'}`}>Профіль не заповнено</Text>
+        <TouchableOpacity onPress={() => navigation.navigate('EditProfile')} className="mt-4 bg-blue-500 p-3 rounded">
+          <Text className="text-white">Створити</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
   return (
-    <View className={`flex-1 items-center justify-center ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>
-      <Text className={`${theme === 'light' ? 'text-black' : 'text-white'}`}>Profile Screen</Text>
-    </View>
+    <ScrollView className={`flex-1 p-4 ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>\
+      {profile.photos[0] && <Image source={{ uri: profile.photos[0] }} className="w-full h-64 rounded mb-4" />}
+      <Text className={`text-2xl font-bold ${theme === 'light' ? 'text-black' : 'text-white'}`}>{profile.name}{profile.age && !profile.hideAge ? `, ${profile.age}` : ''}</Text>
+      {profile.bio ? <Text className="mt-2 text-gray-500">{profile.bio}</Text> : null}
+      {profile.interests.length > 0 && (
+        <View className="flex-row flex-wrap mt-2">
+          {profile.interests.map((i) => (
+            <Text key={i} className="px-2 py-1 mr-2 mb-2 bg-gray-200 rounded">{i}</Text>
+          ))}
+        </View>
+      )}
+      <View className="mt-4 space-y-1">
+        {profile.gender ? <Text className="text-gray-500">Стать: {profile.gender}</Text> : null}
+        {profile.orientation ? <Text className="text-gray-500">Орієнтація: {profile.orientation}</Text> : null}
+        {profile.job ? <Text className="text-gray-500">Робота: {profile.job}</Text> : null}
+        {profile.education ? <Text className="text-gray-500">Освіта: {profile.education}</Text> : null}
+        {profile.height && !profile.hideAge ? <Text className="text-gray-500">Зріст: {profile.height}</Text> : null}
+      </View>
+      {profile.photos.length > 1 && (
+        <View className="flex-row flex-wrap mt-4">
+          {profile.photos.slice(1).map((p, idx) => (
+            <Image key={idx} source={{ uri: p }} className="w-24 h-24 mr-2 mb-2 rounded" />
+          ))}
+        </View>
+      )}
+      <TouchableOpacity onPress={() => navigation.navigate('EditProfile')} className="mt-6 bg-blue-500 p-3 rounded">
+        <Text className="text-white text-center">Редагувати</Text>
+      </TouchableOpacity>
+    </ScrollView>
   );
 }


### PR DESCRIPTION
## Summary
- create `EditProfileScreen` to manage profile data in AsyncStorage
- load profile details on `ProfileScreen`
- link new edit screen in navigation stack

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845ea5befc08331b102819b3c6f27cf