### PR TITLE
Implement mobile chat UI

### DIFF
--- a/mobile/mockData.js
+++ b/mobile/mockData.js
@@ -1,0 +1,26 @@
+export const users = [
+  {
+    id: 1,
+    name: 'Аліса',
+    avatar: 'https://placehold.co/100x100?text=А',
+    photo: 'https://placehold.co/320x400?text=Аліса',
+  },
+  {
+    id: 2,
+    name: 'Даша',
+    avatar: 'https://placehold.co/100x100?text=Д',
+    photo: 'https://placehold.co/320x400?text=Даша',
+  },
+  {
+    id: 3,
+    name: 'Ірина',
+    avatar: 'https://placehold.co/100x100?text=І',
+    photo: 'https://placehold.co/320x400?text=Ірина',
+  },
+  {
+    id: 4,
+    name: 'Марія',
+    avatar: 'https://placehold.co/100x100?text=М',
+    photo: 'https://placehold.co/320x400?text=Марія',
+  },
+];

--- a/mobile/screens/ChatScreen.js
+++ b/mobile/screens/ChatScreen.js
@@ -1,12 +1,125 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  ScrollView,
+  TouchableOpacity,
+  Image,
+} from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useTheme } from '../context/ThemeContext';
+import { users } from '../mockData';
 
-export default function ChatScreen() {
+export default function ChatScreen({ route }) {
   const { theme } = useTheme();
+  const { userId } = route.params || {};
+  const id = userId ? parseInt(userId, 10) : null;
+  const partner =
+    users.find((u) => u.id === id) || { id, name: 'Користувач', avatar: '' };
+
+  const currentUser = { name: 'You', avatar: '' };
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const scrollRef = useRef(null);
+
+  useEffect(() => {
+    if (id) {
+      AsyncStorage.getItem(`chat-${id}`).then((saved) => {
+        if (saved) setMessages(JSON.parse(saved));
+      });
+    }
+  }, [id]);
+
+  useEffect(() => {
+    if (id) {
+      AsyncStorage.setItem(`chat-${id}`, JSON.stringify(messages));
+      scrollRef.current?.scrollToEnd({ animated: true });
+    }
+  }, [messages, id]);
+
+  const handleSend = () => {
+    if (!input.trim()) return;
+    const time = new Date().toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+    const newMsg = {
+      id: Date.now().toString(),
+      from: currentUser.name,
+      avatar: currentUser.avatar,
+      text: input.trim(),
+      time,
+      side: 'right',
+    };
+    setMessages((prev) => [...prev, newMsg]);
+    setInput('');
+
+    setTimeout(() => {
+      const reply = {
+        id: (Date.now() + 1).toString(),
+        from: partner.name,
+        avatar: partner.avatar,
+        text: 'Це авто-відповідь 😄',
+        time: new Date().toLocaleTimeString([], {
+          hour: '2-digit',
+          minute: '2-digit',
+        }),
+        side: 'left',
+      };
+      setMessages((prev) => [...prev, reply]);
+    }, 1500);
+  };
+
+  if (!id) {
+    return (
+      <View className={`flex-1 items-center justify-center ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>
+        <Text className={`${theme === 'light' ? 'text-black' : 'text-white'}`}>Немає чату</Text>
+      </View>
+    );
+  }
+
   return (
-    <View className={`flex-1 items-center justify-center ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>
-      <Text className={`${theme === 'light' ? 'text-black' : 'text-white'}`}>Chat Screen</Text>
+    <View className={`flex-1 p-4 ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>
+      <Text className={`text-lg font-bold mb-4 ${theme === 'light' ? 'text-black' : 'text-white'}`}>Чат з {partner.name}</Text>
+      <ScrollView
+        ref={scrollRef}
+        className={`flex-1 rounded-lg p-3 ${theme === 'light' ? 'bg-gray-100' : 'bg-zinc-800'}`}
+      >
+        {messages.map((msg) => (
+          <View key={msg.id} className={`mb-2 ${msg.side === 'right' ? 'items-end' : 'items-start'} flex`}>
+            <View className={`flex-row items-end ${msg.side === 'right' ? 'flex-row-reverse' : ''}`}>
+              {msg.avatar ? (
+                <Image source={{ uri: msg.avatar }} className="w-8 h-8 rounded-full mx-1" />
+              ) : null}
+              <View>
+                <View className={`px-3 py-2 rounded-xl ${theme === 'light' ? 'bg-gray-200' : 'bg-zinc-900'}`}>
+                  <Text className={theme === 'light' ? 'text-black' : 'text-white'}>{msg.text}</Text>
+                </View>
+                <Text className="text-xs text-gray-500 mt-1 text-right">{msg.time}</Text>
+              </View>
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+      <View className="mt-3 flex-row items-center">
+        <TextInput
+          value={input}
+          onChangeText={setInput}
+          placeholder="Напишіть повідомлення..."
+          className={`flex-1 border rounded-lg px-3 py-2 ${
+            theme === 'light' ? 'bg-white text-black' : 'bg-zinc-900 text-white'
+          }`}
+        />
+        <TouchableOpacity
+          onPress={handleSend}
+          className={`ml-2 px-4 py-2 rounded-lg ${
+            theme === 'light' ? 'bg-purple-500' : 'bg-purple-600'
+          }`}
+        >
+          <Text className="text-white">Надіслати</Text>
+        </TouchableOpacity>
+      </View>
     </View>
   );
 }

--- a/mobile/screens/MatchesScreen.js
+++ b/mobile/screens/MatchesScreen.js
@@ -1,12 +1,136 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  ScrollView,
+  TouchableOpacity,
+  Image,
+} from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useTheme } from '../context/ThemeContext';
+import { users } from '../mockData';
 
-export default function MatchesScreen() {
+export default function MatchesScreen({ navigation }) {
   const { theme } = useTheme();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [conversations, setConversations] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const chats = await Promise.all(
+        users.map(async (u) => {
+          const saved = await AsyncStorage.getItem(`chat-${u.id}`);
+          if (saved) {
+            const arr = JSON.parse(saved);
+            const last = arr[arr.length - 1];
+            if (last) {
+              return {
+                id: u.id,
+                name: u.name,
+                avatar: u.avatar,
+                text: last.text,
+                time: last.time,
+              };
+            }
+          }
+          return null;
+        })
+      );
+      setConversations(chats.filter(Boolean));
+    };
+    const unsubscribe = navigation.addListener('focus', load);
+    return unsubscribe;
+  }, [navigation]);
+
+  const filteredConversations = conversations.filter((c) =>
+    c.name.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  const matchedIds = conversations.map((c) => c.id);
+  const newMatches = users.filter((u) => !matchedIds.includes(u.id));
+  const filteredMatches = newMatches.filter((m) =>
+    m.name.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
   return (
-    <View className={`flex-1 items-center justify-center ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>
-      <Text className={`${theme === 'light' ? 'text-black' : 'text-white'}`}>Matches Screen</Text>
+    <View className={`flex-1 p-4 ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>
+      <TextInput
+        placeholder="Пошук..."
+        value={searchTerm}
+        onChangeText={setSearchTerm}
+        className={`border px-3 py-2 rounded mb-4 ${
+          theme === 'light' ? 'text-black bg-white' : 'text-white bg-zinc-800'
+        }`}
+      />
+
+      <View>
+        <Text
+          className={`font-bold mb-2 ${
+            theme === 'light' ? 'text-black' : 'text-white'
+          }`}
+        >
+          Нові пари
+        </Text>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} className="pb-2">
+          {filteredMatches.map((match) => (
+            <TouchableOpacity
+              key={match.id}
+              onPress={() => navigation.navigate('Chat', { userId: match.id })}
+              className="items-center mr-4"
+            >
+              <Image
+                source={{ uri: match.avatar }}
+                className="w-16 h-16 rounded-full border-2 border-purple-500"
+              />
+              <Text className="text-xs mt-1 text-center text-gray-500 w-16" numberOfLines={1}>
+                {match.name}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
+      </View>
+
+      <View className="flex-1 mt-4">
+        <Text
+          className={`font-bold mb-2 ${
+            theme === 'light' ? 'text-black' : 'text-white'
+          }`}
+        >
+          Повідомлення
+        </Text>
+        <ScrollView>
+          {filteredConversations.map((msg) => (
+            <TouchableOpacity
+              key={msg.id}
+              onPress={() => navigation.navigate('Chat', { userId: msg.id })}
+              className={`flex-row items-center p-2 rounded-lg mb-2 ${
+                theme === 'light' ? 'bg-gray-100' : 'bg-zinc-800'
+              }`}
+            >
+              <Image
+                source={{ uri: msg.avatar }}
+                className="w-10 h-10 rounded-full mr-3"
+              />
+              <View className="flex-1">
+                <View className="flex-row justify-between">
+                  <Text
+                    className={`font-semibold ${
+                      theme === 'light' ? 'text-black' : 'text-white'
+                    }`}
+                  >
+                    {msg.name}
+                  </Text>
+                  <Text className="text-xs text-gray-400">{msg.time}</Text>
+                </View>
+                <Text className="text-sm text-gray-500" numberOfLines={1}>
+                  {msg.text}
+                </Text>
+              </View>
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
+      </View>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- add sample user data for mobile
- build MatchesScreen with search and message previews
- build ChatScreen with full chat UI and simulated replies

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845eca0c6188331878771d2ff48c183