### PR TITLE
Add settings and info screens

### DIFF
--- a/src/AboutAppScreen.jsx
+++ b/src/AboutAppScreen.jsx
@@ -1,0 +1,24 @@
+import { useTheme } from "./ThemeContext";
+import { useLanguage } from "./LanguageContext";
+import LanguageThemeSwitcher from "./LanguageThemeSwitcher";
+
+export default function AboutAppScreen() {
+  const { theme } = useTheme();
+  const { language } = useLanguage();
+
+  return (
+    <div
+      className={`w-full max-w-[430px] mx-auto min-h-[800px] p-6 rounded-2xl shadow-xl transition-all duration-300 flex flex-col gap-6 ${
+        theme === "light" ? "bg-warm text-black" : "bg-darkbg text-textwarm"
+      }`}
+    >
+      <h2 className="text-2xl font-bold text-center">{language === "ua" ? "\u041f\u0440\u043e \u0437\u0430\u0441\u0442\u043e\u0441\u0443\u043d\u043e\u043a" : "About App"}</h2>
+      <p className="text-sm leading-relaxed">
+        {language === "ua"
+          ? "CatchYou \u2014 \u0446\u0435 \u0434\u0435\u043c\u043e \u0434\u043e\u0434\u0430\u0442\u043e\u043a \u0434\u043b\u044f \u043d\u0430\u0439\u043e\u0448\u0442\u0440\u0435\u043d\u0435\u043d\u043d\u044f \u0437\u043d\u0430\u0439\u043e\u043c\u0441\u0442\u0432. \u0412\u0456\u043d \u0441\u0442\u0432\u043e\u0440\u0435\u043d\u0438\u0439 \u0434\u043b\u044f \u0434\u043e\u043a\u0430\u0437\u0443 \u043a\u043e\u043d\u0446\u0435\u043f\u0446\u0456\u0457 \u0456 \u043d\u0435 \u043f\u0440\u0435\u0442\u0435\u043d\u0434\u0443\u0454 \u043d\u0430 \u043f\u043e\u0432\u043d\u0443 \u0444\u0443\u043d\u043a\u0446\u0456\u043e\u043d\u0430\u043b\u044c\u043d\u0456\u0441\u0442\u044c."
+          : "CatchYou is a demo dating app showcasing basic interface ideas. It is built for concept demonstration and does not aim to provide full functionality."}
+      </p>
+      <LanguageThemeSwitcher />
+    </div>
+  );
+}

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,9 @@ import EditProfileScreen from "./EditProfileScreen";
 import BottomNavBar from "./BottomNavBar";
 import ChatConversationScreen from "./ChatConversationScreen";
 import MatchesScreen from "./MatchesScreen";
+import SettingsScreen from "./SettingsScreen";
+import AboutAppScreen from "./AboutAppScreen";
+import HelpScreen from "./HelpScreen";
 
 
 function AppContent() {
@@ -36,6 +39,9 @@ function AppContent() {
           <Route path="/profile" element={<UserProfileScreen />} />
           <Route path="/edit-profile" element={<EditProfileScreen />} />
           <Route path="/chat/:userId" element={<ChatConversationScreen />} />
+          <Route path="/settings" element={<SettingsScreen />} />
+          <Route path="/about" element={<AboutAppScreen />} />
+          <Route path="/help" element={<HelpScreen />} />
         </Routes>
 
         {shouldShowNav && <BottomNavBar />}

--- a/src/BottomNavBar.jsx
+++ b/src/BottomNavBar.jsx
@@ -1,5 +1,5 @@
 import { NavLink } from "react-router-dom";
-import { FaHome, FaComment, FaUser, FaMoon, FaSun } from "react-icons/fa";
+import { FaHome, FaComment, FaUser, FaMoon, FaSun, FaCog } from "react-icons/fa";
 import { useTheme } from "./ThemeContext";
 
 export default function BottomNavBar() {
@@ -27,6 +27,10 @@ export default function BottomNavBar() {
 
       <NavLink to="/profile" className={navItemClass} aria-label="Profile">
         <FaUser size={20} />
+      </NavLink>
+
+      <NavLink to="/settings" className={navItemClass} aria-label="Settings">
+        <FaCog size={20} />
       </NavLink>
 
       {/* Theme Toggle */}

--- a/src/HelpScreen.jsx
+++ b/src/HelpScreen.jsx
@@ -1,0 +1,52 @@
+import { useTheme } from "./ThemeContext";
+import { useLanguage } from "./LanguageContext";
+import LanguageThemeSwitcher from "./LanguageThemeSwitcher";
+
+export default function HelpScreen() {
+  const { theme } = useTheme();
+  const { language } = useLanguage();
+
+  const faqs = {
+    ua: [
+      {
+        q: "\u042f\u043a \u0441\u0442\u0432\u043e\u0440\u0438\u0442\u0438 \u043f\u0440\u043e\u0444\u0456\u043b?",
+        a: "\u041f\u0435\u0440\u0435\u0439\u0434\u0456\u0442\u044c \u0434\u043e \u0420\u0435\u0434\u0430\u0433\u0443\u0432\u0430\u043d\u043d\u044f \u043f\u0440\u043e\u0444\u0456\u043b\u044e \u0456 \u0437\u0430\u043f\u043e\u0432\u043d\u0456\u0442\u044c \u043f\u043e\u043b\u044f."
+      },
+      {
+        q: "\u042f\u043a \u043f\u043e\u0448\u0443\u043a \u043f\u0430\u0440?",
+        a: "\u041f\u0435\u0440\u0435\u0433\u043b\u044f\u0434\u0430\u0439\u0442\u0435 \u043a\u0430\u0440\u0442\u043a\u0438 \u043d\u0430 \u0435\u043a\u0440\u0430\u043d\u0456 \u0441\u0432\u0430\u0439\u043f\u0456\u0432 \u0456 \u0441\u0432\u0430\u0439\u043f\u043d\u0456\u0442\u044c \u043b\u0456\u0432\u043e \u0430\u0431\u043e \u043f\u0440\u0430\u0432\u043e."
+      }
+    ],
+    en: [
+      {
+        q: "How do I create a profile?",
+        a: "Go to Edit Profile and fill in your details."
+      },
+      {
+        q: "How does matching work?",
+        a: "Browse cards on the swipe screen and swipe left or right."
+      }
+    ]
+  };
+
+  const list = faqs[language];
+
+  return (
+    <div
+      className={`w-full max-w-[430px] mx-auto min-h-[800px] p-6 rounded-2xl shadow-xl transition-all duration-300 flex flex-col gap-6 ${
+        theme === "light" ? "bg-warm text-black" : "bg-darkbg text-textwarm"
+      }`}
+    >
+      <h2 className="text-2xl font-bold text-center">{language === "ua" ? "\u0414\u043e\u043f\u043e\u043c\u043e\u0433\u0430" : "Help"}</h2>
+      <div className="space-y-4 text-sm">
+        {list.map((item, i) => (
+          <div key={i}>
+            <p className="font-semibold">{item.q}</p>
+            <p className="ml-2">{item.a}</p>
+          </div>
+        ))}
+      </div>
+      <LanguageThemeSwitcher />
+    </div>
+  );
+}

--- a/src/SettingsScreen.jsx
+++ b/src/SettingsScreen.jsx
@@ -1,0 +1,76 @@
+import { useNavigate } from "react-router-dom";
+import { ThemeToggle } from "./ThemeToggle";
+import { useTheme } from "./ThemeContext";
+import { useLanguage } from "./LanguageContext";
+import LanguageThemeSwitcher from "./LanguageThemeSwitcher";
+
+export default function SettingsScreen() {
+  const { theme } = useTheme();
+  const { language, setLanguage } = useLanguage();
+  const navigate = useNavigate();
+
+  const handleSignOut = () => {
+    localStorage.removeItem("userProfile");
+    navigate("/", { replace: true });
+  };
+
+  return (
+    <div
+      className={`w-full max-w-[430px] mx-auto min-h-[800px] p-6 rounded-2xl shadow-xl transition-all duration-300 flex flex-col gap-6 ${
+        theme === "light" ? "bg-warm text-black" : "bg-darkbg text-textwarm"
+      }`}
+    >
+      <h2 className="text-2xl font-bold text-center">{language === "ua" ? "\u041d\u0430\u043b\u0430\u0448\u0442\u0443\u0432\u0430\u043d\u043d\u044f" : "Settings"}</h2>
+
+      <div className="flex justify-between items-center">
+        <span>{language === "ua" ? "\u0422\u0435\u043c\u0430" : "Theme"}</span>
+        <ThemeToggle />
+      </div>
+
+      <div className="flex justify-between items-center">
+        <span>{language === "ua" ? "\u041c\u043e\u0432\u0430" : "Language"}</span>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setLanguage("ua")}
+            className={`px-3 py-1 rounded transition border text-sm ${
+              language === "ua"
+                ? theme === "light"
+                  ? "bg-pastelPurple text-white"
+                  : "bg-purple-600 text-textwarm"
+                : theme === "light"
+                ? "border-zinc-300"
+                : "border-zinc-700"
+            }`}
+          >
+            UA
+          </button>
+          <button
+            onClick={() => setLanguage("en")}
+            className={`px-3 py-1 rounded transition border text-sm ${
+              language === "en"
+                ? theme === "light"
+                  ? "bg-pastelPurple text-white"
+                  : "bg-purple-600 text-textwarm"
+                : theme === "light"
+                ? "border-zinc-300"
+                : "border-zinc-700"
+            }`}
+          >
+            EN
+          </button>
+        </div>
+      </div>
+
+      <button
+        onClick={handleSignOut}
+        className={`mt-auto py-3 rounded-xl font-semibold transition w-full ${
+          theme === "light" ? "bg-pastelPurple text-white hover:bg-purple-400" : "bg-purple-600 text-textwarm hover:bg-purple-700"
+        }`}
+      >
+        {language === "ua" ? "\u0412\u0438\u0439\u0442\u0438" : "Sign Out"}
+      </button>
+
+      <LanguageThemeSwitcher />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add SettingsScreen with theme, language, and sign-out controls
- add AboutAppScreen with static information
- add HelpScreen with simple FAQ content
- update routes in App and add Settings icon to bottom nav

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ef2a130c8331b782e84a3a3de115