### PR TITLE
Implement basic session storage

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -13,6 +13,7 @@ import SettingsScreen from './screens/SettingsScreen';
 import EditProfileScreen from './screens/EditProfileScreen';
 import { ThemeProvider } from './context/ThemeContext';
 import { LanguageProvider } from './context/LanguageContext';
+import { AuthProvider, useAuth } from './context/AuthContext';
 
 const Stack = createStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -31,25 +32,46 @@ function HomeTabs() {
   );
 }
 
+function RootNavigator() {
+  const { userToken, loading } = useAuth();
+
+  if (loading) {
+    return null;
+  }
+
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: false,
+        gestureEnabled: true,
+      }}
+    >
+      {userToken ? (
+        <>
+          <Stack.Screen name="Home" component={HomeTabs} />
+          <Stack.Screen name="EditProfile" component={EditProfileScreen} />
+        </>
+      ) : (
+        <>
+          <Stack.Screen name="Welcome" component={WelcomeScreen} />
+          <Stack.Screen name="Login" component={LoginScreen} />
+          <Stack.Screen name="Register" component={RegisterScreen} />
+          <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} />
+        </>
+      )}
+    </Stack.Navigator>
+  );
+}
+
 export default function App() {
   return (
     <ThemeProvider>
       <LanguageProvider>
-        <NavigationContainer>
-          <Stack.Navigator
-            screenOptions={{
-              headerShown: false,
-              gestureEnabled: true,
-            }}
-          >
-            <Stack.Screen name="Welcome" component={WelcomeScreen} />
-            <Stack.Screen name="Login" component={LoginScreen} />
-            <Stack.Screen name="Register" component={RegisterScreen} />
-            <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} />
-            <Stack.Screen name="Home" component={HomeTabs} />
-            <Stack.Screen name="EditProfile" component={EditProfileScreen} />
-          </Stack.Navigator>
-        </NavigationContainer>
+        <AuthProvider>
+          <NavigationContainer>
+            <RootNavigator />
+          </NavigationContainer>
+        </AuthProvider>
       </LanguageProvider>
     </ThemeProvider>
   );

--- a/mobile/context/AuthContext.js
+++ b/mobile/context/AuthContext.js
@@ -1,0 +1,36 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [userToken, setUserToken] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    AsyncStorage.getItem('userToken').then((token) => {
+      if (token) {
+        setUserToken(token);
+      }
+      setLoading(false);
+    });
+  }, []);
+
+  const login = async (token) => {
+    await AsyncStorage.setItem('userToken', token);
+    setUserToken(token);
+  };
+
+  const logout = async () => {
+    await AsyncStorage.removeItem('userToken');
+    setUserToken(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ userToken, login, logout, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/mobile/screens/LoginScreen.js
+++ b/mobile/screens/LoginScreen.js
@@ -5,10 +5,12 @@ import CustomButton from '../components/CustomButton';
 import LanguageThemeSwitcher from '../components/LanguageThemeSwitcher';
 import { useTheme } from '../context/ThemeContext';
 import { useLanguage } from '../context/LanguageContext';
+import { useAuth } from '../context/AuthContext';
 
 export default function LoginScreen({ navigation }) {
   const { theme } = useTheme();
   const { language } = useLanguage();
+  const { login } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -42,7 +44,7 @@ export default function LoginScreen({ navigation }) {
       return;
     }
     setError('');
-    navigation.replace('Home');
+    login('demo-token');
   };
 
   return (

--- a/mobile/screens/RegisterScreen.js
+++ b/mobile/screens/RegisterScreen.js
@@ -4,10 +4,12 @@ import CustomButton from '../components/CustomButton';
 import LanguageThemeSwitcher from '../components/LanguageThemeSwitcher';
 import { useTheme } from '../context/ThemeContext';
 import { useLanguage } from '../context/LanguageContext';
+import { useAuth } from '../context/AuthContext';
 
 export default function RegisterScreen({ navigation }) {
   const { theme } = useTheme();
   const { language } = useLanguage();
+  const { login } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
@@ -40,7 +42,7 @@ export default function RegisterScreen({ navigation }) {
       return;
     }
     setError('');
-    navigation.replace('Home');
+    login('demo-token');
   };
 
   return (

--- a/mobile/screens/SettingsScreen.js
+++ b/mobile/screens/SettingsScreen.js
@@ -1,12 +1,16 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
 import { useTheme } from '../context/ThemeContext';
+import { useAuth } from '../context/AuthContext';
 
 export default function SettingsScreen() {
   const { theme } = useTheme();
+  const { logout } = useAuth();
   return (
     <View className={`flex-1 items-center justify-center ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>
-      <Text className={`${theme === 'light' ? 'text-black' : 'text-white'}`}>Settings Screen</Text>
+      <TouchableOpacity onPress={logout} className="bg-blue-500 p-3 rounded">
+        <Text className="text-white">Logout</Text>
+      </TouchableOpacity>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- add new `AuthContext` with AsyncStorage persistence
- conditionally show login or home screens based on session
- store token when logging in or registering
- allow logout from settings

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845f026c0cc8331b281a14ee2ab1be1