### PR TITLE
Add notifications and permission setup

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
@@ -14,6 +14,8 @@ import EditProfileScreen from './screens/EditProfileScreen';
 import { ThemeProvider } from './context/ThemeContext';
 import { LanguageProvider } from './context/LanguageContext';
 import { AuthProvider, useAuth } from './context/AuthContext';
+import { registerForPushNotificationsAsync } from './utils/notifications';
+import { requestPermissions } from './utils/permissions';
 
 const Stack = createStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -64,6 +66,14 @@ function RootNavigator() {
 }
 
 export default function App() {
+  useEffect(() => {
+    registerForPushNotificationsAsync().then((token) => {
+      if (token) {
+        console.log('Expo push token:', token);
+      }
+    });
+    requestPermissions();
+  }, []);
   return (
     <ThemeProvider>
       <LanguageProvider>

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -5,6 +5,7 @@
     "version": "1.0.0",
     "sdkVersion": "53.0.0",
     "platforms": ["ios", "android", "web"],
-    "entryPoint": "./App.js"
+    "entryPoint": "./App.js",
+    "plugins": ["expo-notifications"]
   }
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -23,6 +23,11 @@
     "react-native-screens": "^4.11.1",
     "react-native-safe-area-context": "^5.4.1",
     "react-native-gesture-handler": "^2.25.0",
-    "@react-native-async-storage/async-storage": "^1.21.0"
+    "@react-native-async-storage/async-storage": "^1.21.0",
+    "expo-notifications": "^0.31.3",
+    "expo-device": "^7.1.4",
+    "expo-camera": "^16.1.7",
+    "expo-media-library": "^17.1.7",
+    "expo-location": "^18.1.5"
   }
 }

--- a/mobile/utils/notifications.js
+++ b/mobile/utils/notifications.js
@@ -1,0 +1,33 @@
+import * as Notifications from 'expo-notifications';
+import * as Device from 'expo-device';
+import { Platform } from 'react-native';
+
+export async function registerForPushNotificationsAsync() {
+  let token = null;
+  if (Device.isDevice) {
+    const { status: existingStatus } = await Notifications.getPermissionsAsync();
+    let finalStatus = existingStatus;
+    if (existingStatus !== 'granted') {
+      const { status } = await Notifications.requestPermissionsAsync();
+      finalStatus = status;
+    }
+    if (finalStatus !== 'granted') {
+      console.log('Failed to get push token for push notification!');
+      return null;
+    }
+    const response = await Notifications.getExpoPushTokenAsync();
+    token = response.data;
+  } else {
+    console.log('Must use physical device for Push Notifications');
+  }
+
+  if (Platform.OS === 'android') {
+    await Notifications.setNotificationChannelAsync('default', {
+      name: 'default',
+      importance: Notifications.AndroidImportance.MAX,
+      vibrationPattern: [0, 250, 250, 250],
+      lightColor: '#FF231F7C',
+    });
+  }
+  return token;
+}

--- a/mobile/utils/permissions.js
+++ b/mobile/utils/permissions.js
@@ -1,0 +1,19 @@
+import { Camera } from 'expo-camera';
+import * as MediaLibrary from 'expo-media-library';
+import * as Location from 'expo-location';
+
+export async function requestPermissions() {
+  try {
+    const { status: cameraStatus } = await Camera.requestCameraPermissionsAsync();
+    const { status: mediaStatus } = await MediaLibrary.requestPermissionsAsync();
+    const { status: locationStatus } = await Location.requestForegroundPermissionsAsync();
+    return {
+      camera: cameraStatus === 'granted',
+      media: mediaStatus === 'granted',
+      location: locationStatus === 'granted',
+    };
+  } catch (error) {
+    console.warn('Error requesting permissions', error);
+    return { camera: false, media: false, location: false };
+  }
+}


### PR DESCRIPTION
## Summary
- add expo-notifications setup and permission helpers
- request camera, media library and location access
- register for push notifications on app start
- update mobile `package.json` dependencies
- configure `app.json` with notifications plugin

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f1ff356c8331907c51309d13001b