### PR TITLE
Use SecureStore for auth token

### DIFF
--- a/mobile/context/AuthContext.js
+++ b/mobile/context/AuthContext.js
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
 
 const AuthContext = createContext();
 
@@ -8,7 +8,7 @@ export function AuthProvider({ children }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    AsyncStorage.getItem('userToken').then((token) => {
+    SecureStore.getItemAsync('userToken').then((token) => {
       if (token) {
         setUserToken(token);
       }
@@ -17,12 +17,14 @@ export function AuthProvider({ children }) {
   }, []);
 
   const login = async (token) => {
-    await AsyncStorage.setItem('userToken', token);
+    await SecureStore.setItemAsync('userToken', token, {
+      keychainAccessible: SecureStore.ALWAYS,
+    });
     setUserToken(token);
   };
 
   const logout = async () => {
-    await AsyncStorage.removeItem('userToken');
+    await SecureStore.deleteItemAsync('userToken');
     setUserToken(null);
   };
 

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -18,6 +18,7 @@
         "expo-location": "^18.1.5",
         "expo-media-library": "^17.1.7",
         "expo-notifications": "^0.31.3",
+        "expo-secure-store": "^12.8.1",
         "nativewind": "^4.1.23",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -4579,6 +4580,15 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "12.8.1",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-12.8.1.tgz",
+      "integrity": "sha512-Ju3jmkHby4w7rIzdYAt9kQyQ7HhHJ0qRaiQOInknhOLIltftHjEgF4I1UmzKc7P5RCfGNmVbEH729Pncp/sHXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/exponential-backoff": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -20,6 +20,7 @@
     "expo-location": "^18.1.5",
     "expo-media-library": "^17.1.7",
     "expo-notifications": "^0.31.3",
+    "expo-secure-store": "^12.8.1",
     "nativewind": "^4.1.23",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
## Summary
- store auth token using expo-secure-store instead of AsyncStorage
- add expo-secure-store dependency

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68466c22d8188331b26f24d84c6bf6ff