### PR TITLE
Fix missing babel config path

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,6 @@
-module.exports = function(api) {
-  return require('./mobile/babel.config.js')(api);
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
 };

--- a/mobile-new/babel.config.js
+++ b/mobile-new/babel.config.js
@@ -1,3 +1,6 @@
-module.exports = function(api) {
-  return require('./mobile/babel.config.js')(api);
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
 };


### PR DESCRIPTION
## Summary
- fix babel config path so project builds correctly

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: no output due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6846a4fd43a483318644ee3e1f05465c