### PR TITLE
Sync mobile styles with web

### DIFF
--- a/mobile-new/components/CustomButton.js
+++ b/mobile-new/components/CustomButton.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import { TouchableOpacity, Text } from 'react-native';
+import { useTheme } from '../context/ThemeContext';
 
 export default function CustomButton({ title, onPress }) {
+  const { theme } = useTheme();
   return (
     <TouchableOpacity
-      className="bg-blue-500 p-3 rounded min-h-[44px] justify-center"
+      className={`p-3 rounded min-h-[44px] justify-center ${theme === 'light' ? 'bg-pastelPurple' : 'bg-purple-600'}`}
       onPress={onPress}
     >
       <Text className="text-white text-center">{title}</Text>

--- a/mobile-new/screens/ForgotPasswordScreen.js
+++ b/mobile-new/screens/ForgotPasswordScreen.js
@@ -31,19 +31,28 @@ export default function ForgotPasswordScreen({ navigation }) {
   const t = texts[language];
 
   return (
-    <SafeAreaWrapper className={`items-center justify-center p-4 ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>
-      <Text className={`text-xl mb-2 ${theme === 'light' ? 'text-black' : 'text-white'}`}>{t.title}</Text>
-      <Text className="text-sm text-gray-500 mb-4">{t.description}</Text>
-      <TextInput
-        className="w-full border p-2 mb-4 rounded"
-        placeholder={t.email}
-        value={email}
-        onChangeText={setEmail}
-      />
-      <CustomButton title={t.submit} onPress={() => navigation.goBack()} />
-      <TouchableOpacity onPress={() => navigation.goBack()} className="mt-4">
-        <Text className="text-sm text-gray-500 underline">{t.back}</Text>
-      </TouchableOpacity>
+    <SafeAreaWrapper
+      className={`flex-1 flex-col justify-between items-center w-full px-6 py-8 ${
+        theme === 'light' ? 'bg-warm text-black' : 'bg-darkbg text-textwarm'
+      }`}
+    >
+      <View className="w-full">
+        <Text className="text-2xl font-bold text-center mt-4 mb-6">{t.title}</Text>
+        <Text className="text-sm text-gray-400 text-center mb-4">{t.description}</Text>
+        <TextInput
+          className={`px-4 py-3 rounded-xl mb-4 shadow-inner ${
+            theme === 'light' ? 'bg-white text-black' : 'bg-zinc-900 text-textwarm'
+          }`}
+          placeholder={t.email}
+          placeholderTextColor={theme === 'light' ? '#6b7280' : '#9ca3af'}
+          value={email}
+          onChangeText={setEmail}
+        />
+        <CustomButton title={t.submit} onPress={() => navigation.goBack()} />
+        <TouchableOpacity onPress={() => navigation.goBack()} className="pt-6 min-h-[44px] justify-center">
+          <Text className="text-sm text-gray-400 underline text-center">{t.back}</Text>
+        </TouchableOpacity>
+      </View>
       <LanguageThemeSwitcher labels={{ ua: { ua: texts.ua.ua, en: texts.ua.en, toggle: texts.ua.toggle }, en: { ua: texts.en.ua, en: texts.en.en, toggle: texts.en.toggle } }} />
     </SafeAreaWrapper>
   );

--- a/mobile-new/screens/LoginScreen.js
+++ b/mobile-new/screens/LoginScreen.js
@@ -49,29 +49,43 @@ export default function LoginScreen({ navigation }) {
   };
 
   return (
-    <SafeAreaWrapper className={`items-center justify-center p-4 ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>
-      <Text className={`text-xl mb-4 ${theme === 'light' ? 'text-black' : 'text-white'}`}>{t.title}</Text>
-      {error ? <Text className="text-red-500 mb-2">{error}</Text> : null}
-      <TextInput
-        className="w-full border p-2 mb-3 rounded"
-        placeholder={t.email}
-        value={email}
-        onChangeText={setEmail}
-      />
-      <TextInput
-        className="w-full border p-2 mb-3 rounded"
-        placeholder={t.password}
-        secureTextEntry
-        value={password}
-        onChangeText={setPassword}
-      />
-      <CustomButton title={t.submit} onPress={handleSubmit} />
-      <TouchableOpacity
-        onPress={() => navigation.navigate('ForgotPassword')}
-        className="mt-2 min-h-[44px] justify-center"
-      >
-        <Text className="text-blue-500 underline">{t.forgot}</Text>
-      </TouchableOpacity>
+    <SafeAreaWrapper
+      className={`flex-1 flex-col justify-between items-center w-full px-6 py-8 ${
+        theme === 'light' ? 'bg-warm text-black' : 'bg-darkbg text-textwarm'
+      }`}
+    >
+      <View className="flex flex-col w-full">
+        <Text className="text-2xl font-bold text-center mt-4 mb-6">{t.title}</Text>
+        {error ? <Text className="text-red-500 mb-2 text-center">{error}</Text> : null}
+        <TextInput
+          className={`px-4 py-3 rounded-xl mb-3 shadow-inner ${
+            theme === 'light' ? 'bg-white text-black' : 'bg-zinc-900 text-textwarm'
+          }`}
+          placeholder={t.email}
+          placeholderTextColor={theme === 'light' ? '#6b7280' : '#9ca3af'}
+          value={email}
+          onChangeText={setEmail}
+        />
+        <TextInput
+          className={`px-4 py-3 rounded-xl mb-3 shadow-inner ${
+            theme === 'light' ? 'bg-white text-black' : 'bg-zinc-900 text-textwarm'
+          }`}
+          placeholder={t.password}
+          placeholderTextColor={theme === 'light' ? '#6b7280' : '#9ca3af'}
+          secureTextEntry
+          value={password}
+          onChangeText={setPassword}
+        />
+        <CustomButton title={t.submit} onPress={handleSubmit} />
+        <View className="text-center pt-6">
+          <TouchableOpacity
+            onPress={() => navigation.navigate('ForgotPassword')}
+            className="min-h-[44px] justify-center"
+          >
+            <Text className="text-sm text-purple-500 underline">{t.forgot}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
       <View className="flex-row space-x-3 mt-6">
         {[ 'apple', 'google', 'facebook', 'instagram' ].map((icon, i) => (
           <TouchableOpacity
@@ -90,7 +104,7 @@ export default function LoginScreen({ navigation }) {
         onPress={() => navigation.navigate('Register')}
         className="mt-4 min-h-[44px] justify-center"
       >
-        <Text className="text-sm text-gray-500 underline">{t.noAccount}</Text>
+        <Text className="text-sm text-gray-400 underline">{t.noAccount}</Text>
       </TouchableOpacity>
       <LanguageThemeSwitcher labels={{ ua: { ua: texts.ua.ua, en: texts.ua.en, toggle: texts.ua.toggle }, en: { ua: texts.en.ua, en: texts.en.en, toggle: texts.en.toggle } }} />
     </SafeAreaWrapper>

--- a/mobile-new/screens/RegisterScreen.js
+++ b/mobile-new/screens/RegisterScreen.js
@@ -47,36 +47,53 @@ export default function RegisterScreen({ navigation }) {
   };
 
   return (
-    <SafeAreaWrapper className={`items-center justify-center p-4 ${theme === 'light' ? 'bg-white' : 'bg-black'}`}>
-      <Text className={`text-xl mb-4 ${theme === 'light' ? 'text-black' : 'text-white'}`}>{t.title}</Text>
-      {error ? <Text className="text-red-500 mb-2">{error}</Text> : null}
-      <TextInput
-        className="w-full border p-2 mb-3 rounded"
-        placeholder={t.email}
-        value={email}
-        onChangeText={setEmail}
-      />
-      <TextInput
-        className="w-full border p-2 mb-3 rounded"
-        placeholder={t.password}
-        secureTextEntry
-        value={password}
-        onChangeText={setPassword}
-      />
-      <TextInput
-        className="w-full border p-2 mb-6 rounded"
-        placeholder={t.confirm}
-        secureTextEntry
-        value={confirm}
-        onChangeText={setConfirm}
-      />
-      <CustomButton title={t.submit} onPress={handleSubmit} />
-      <TouchableOpacity
-        onPress={() => navigation.goBack()}
-        className="mt-4 min-h-[44px] justify-center"
-      >
-        <Text className="text-sm text-gray-500 underline">{t.haveAccount}</Text>
-      </TouchableOpacity>
+    <SafeAreaWrapper
+      className={`flex-1 flex-col justify-between items-center w-full px-6 py-8 ${
+        theme === 'light' ? 'bg-warm text-black' : 'bg-darkbg text-textwarm'
+      }`}
+    >
+      <View className="flex flex-col w-full">
+        <Text className="text-2xl font-bold text-center mt-4 mb-6">{t.title}</Text>
+        {error ? <Text className="text-red-500 mb-2 text-center">{error}</Text> : null}
+        <TextInput
+          className={`px-4 py-3 rounded-xl mb-3 shadow-inner ${
+            theme === 'light' ? 'bg-white text-black' : 'bg-zinc-900 text-textwarm'
+          }`}
+          placeholder={t.email}
+          placeholderTextColor={theme === 'light' ? '#6b7280' : '#9ca3af'}
+          value={email}
+          onChangeText={setEmail}
+        />
+        <TextInput
+          className={`px-4 py-3 rounded-xl mb-3 shadow-inner ${
+            theme === 'light' ? 'bg-white text-black' : 'bg-zinc-900 text-textwarm'
+          }`}
+          placeholder={t.password}
+          placeholderTextColor={theme === 'light' ? '#6b7280' : '#9ca3af'}
+          secureTextEntry
+          value={password}
+          onChangeText={setPassword}
+        />
+        <TextInput
+          className={`px-4 py-3 rounded-xl mb-6 shadow-inner ${
+            theme === 'light' ? 'bg-white text-black' : 'bg-zinc-900 text-textwarm'
+          }`}
+          placeholder={t.confirm}
+          placeholderTextColor={theme === 'light' ? '#6b7280' : '#9ca3af'}
+          secureTextEntry
+          value={confirm}
+          onChangeText={setConfirm}
+        />
+        <CustomButton title={t.submit} onPress={handleSubmit} />
+        <View className="text-center pt-6">
+          <TouchableOpacity
+            onPress={() => navigation.goBack()}
+            className="min-h-[44px] justify-center"
+          >
+            <Text className="text-sm text-gray-400 underline">{t.haveAccount}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
       <LanguageThemeSwitcher labels={{ ua: { ua: texts.ua.ua, en: texts.ua.en, toggle: texts.ua.toggle }, en: { ua: texts.en.ua, en: texts.en.en, toggle: texts.en.toggle } }} />
     </SafeAreaWrapper>
   );

--- a/mobile-new/tailwind.config.js
+++ b/mobile-new/tailwind.config.js
@@ -6,7 +6,14 @@ module.exports = {
     "./components/**/*.{js,jsx,ts,tsx}"
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        warm: '#f9f5ee',
+        darkbg: '#121212',
+        textwarm: '#fbead2',
+        pastelPurple: '#b983ff',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add web color palette to mobile Tailwind config
- update CustomButton to use theme-aware colors
- restyle login, register and password recovery screens using web Tailwind classes

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b1e9fcd48331bf53e43eef606a30