### PR TITLE
Fix NativeWind styles on Expo

### DIFF
--- a/mobile-new/babel.config.js
+++ b/mobile-new/babel.config.js
@@ -2,5 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    plugins: ['nativewind/babel'],
   };
 };


### PR DESCRIPTION
## Summary
- add `nativewind/babel` plugin for React Native

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b96161408331bda6d5dd97c3b96d