### PR TITLE
Fix Expo startup by removing root Babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-  };
-};

--- a/mobile-new/README.md
+++ b/mobile-new/README.md
@@ -10,7 +10,7 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    npm install
    ```
 
-2. Start the app
+2. Start the app **from this directory**
 
    ```bash
    npx expo start


### PR DESCRIPTION
## Summary
- remove duplicate `babel.config.js` at repo root
- clarify README to start Expo from the `mobile-new` directory

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bd4e491c83319a62471baac542b7