### PR TITLE
Fix NativeWind Babel config

### DIFF
--- a/mobile-new/babel.config.js
+++ b/mobile-new/babel.config.js
@@ -1,7 +1,7 @@
 module.exports = function (api) {
   api.cache(true);
   return {
-    presets: ['babel-preset-expo'],
-    plugins: ['nativewind/babel'],
+    presets: ['babel-preset-expo', 'nativewind/babel'],
+    plugins: [],
   };
 };


### PR DESCRIPTION
## Summary
- fix the babel configuration so `nativewind` is loaded as a preset

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in `mobile-new` *(no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_6846c318b06c833196dcdc3e22a38bc9